### PR TITLE
Move CustomizeTerminal() to the Expander

### DIFF
--- a/MT4Expander.vcproj
+++ b/MT4Expander.vcproj
@@ -204,6 +204,10 @@
 			UniqueIdentifier="{93995380-89BD-4b04-88EB-625FBE52EBFB}"
 			>
 			<File
+				RelativePath=".\header\dllmain.h"
+				>
+			</File>
+			<File
 				RelativePath=".\header\expander.h"
 				>
 			</File>

--- a/header/dllmain.h
+++ b/header/dllmain.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "expander.h"
+
+BOOL  WINAPI onProcessAttach();
+BOOL  WINAPI onProcessDetach(BOOL isTerminating);
+DWORD WINAPI onExpanderStart(void* lpParam);

--- a/header/lib/file.h
+++ b/header/lib/file.h
@@ -12,7 +12,7 @@ struct REPARSE_DATA_BUFFER {
          USHORT PrintNameOffset;
          USHORT PrintNameLength;
          WCHAR  PathBuffer[1];
-      } MountPointReparseBuffer;
+      } MountPoint;
       struct {
          USHORT SubstituteNameOffset;
          USHORT SubstituteNameLength;
@@ -20,10 +20,10 @@ struct REPARSE_DATA_BUFFER {
          USHORT PrintNameLength;
          ULONG  Flags;
          WCHAR  PathBuffer[1];
-      } SymbolicLinkReparseBuffer;
+      } SymbolicLink;
       struct {
          UCHAR DataBuffer[1];
-      } GenericReparseBuffer;
+      } Generic;
    };
 };
 

--- a/header/lib/terminal.h
+++ b/header/lib/terminal.h
@@ -2,6 +2,7 @@
 #include "expander.h"
 
 
+void         WINAPI CustomizeTerminal();
 const char*  WINAPI FindHistoryDirectoryA(const char* filename, BOOL removeFile);
 HWND         WINAPI FindInputDialogA(ProgramType programType, const char* programName);
 const char*  WINAPI GetExpanderFileNameA();

--- a/header/lib/timeseries.h
+++ b/header/lib/timeseries.h
@@ -15,14 +15,14 @@
  */
 inline double iOpen(const void* rates, uint bars, uint bar) {
    static uint build = GetTerminalBuild();               // TODO: defeats inlining
-   if (!build || bar < 0 || bar >= bars) return(NULL);
+   if (!build || bar < 0 || bar >= bars) return NULL;
 
    uint shift = bars-1-bar;
 
    double open;
    if (build <= 509) open = ((HistoryBar400*) rates)[shift].open;
    else              open = ((HistoryBar401*) rates)[shift].open;
-   return(open);
+   return open;
 }
 
 
@@ -37,13 +37,13 @@ inline double iOpen(const void* rates, uint bars, uint bar) {
  */
 inline double WINAPI iHigh(const void* rates, uint bars, uint bar) {
    static uint build = GetTerminalBuild();               // TODO: defeats inlining
-   if (!build || bar < 0 || bar >= bars) return(NULL);
+   if (!build || bar < 0 || bar >= bars) return NULL;
 
    double high;
    uint shift = bars-1-bar;
    if (build <= 509) high = ((HistoryBar400*) rates)[shift].high;
    else              high = ((HistoryBar401*) rates)[shift].high;
-   return(high);
+   return high;
 }
 
 
@@ -58,13 +58,13 @@ inline double WINAPI iHigh(const void* rates, uint bars, uint bar) {
  */
 inline double WINAPI iLow(const void* rates, uint bars, uint bar) {
    static uint build = GetTerminalBuild();               // TODO: defeats inlining
-   if (!build || bar < 0 || bar >= bars) return(NULL);
+   if (!build || bar < 0 || bar >= bars) return NULL;
 
    double low;
    uint shift = bars-1-bar;
    if (build <= 509) low = ((HistoryBar400*) rates)[shift].low;
    else              low = ((HistoryBar401*) rates)[shift].low;
-   return(low);
+   return low;
 }
 
 
@@ -79,18 +79,18 @@ inline double WINAPI iLow(const void* rates, uint bars, uint bar) {
  */
 inline double WINAPI iClose(const void* rates, uint bars, uint bar) {
    static uint build = GetTerminalBuild();               // TODO: defeats inlining
-   if (!build || bar < 0 || bar >= bars) return(NULL);
+   if (!build || bar < 0 || bar >= bars) return NULL;
 
    double close;
    uint shift = bars-1-bar;
    if (build <= 509) close = ((HistoryBar400*) rates)[shift].close;
    else              close = ((HistoryBar401*) rates)[shift].close;
-   return(close);
+   return close;
 }
 
 
 /**
- * Return the volume of a bar.
+ * Return the tick volume of a bar.
  *
  * @param  void* rates - bar timeseries with youngest prices at the end
  * @param  uint  bars  - number of bars in the series
@@ -100,13 +100,13 @@ inline double WINAPI iClose(const void* rates, uint bars, uint bar) {
  */
 inline uint WINAPI iVolume(const void* rates, uint bars, uint bar) {
    static uint build = GetTerminalBuild();               // TODO: defeats inlining
-   if (!build || bar < 0 || bar >= bars) return(NULL);
+   if (!build || bar < 0 || bar >= bars) return NULL;
 
-   uint volume;
+   uint ticks;
    uint shift = bars-1-bar;
-   if (build <= 509) volume = (uint)((HistoryBar400*) rates)[shift].ticks;
-   else              volume = (uint)((HistoryBar401*) rates)[shift].ticks;
-   return(volume);
+   if (build <= 509) ticks = (uint)((HistoryBar400*) rates)[shift].ticks;
+   else              ticks = (uint)((HistoryBar401*) rates)[shift].ticks;
+   return ticks;
 }
 
 
@@ -121,11 +121,11 @@ inline uint WINAPI iVolume(const void* rates, uint bars, uint bar) {
  */
 inline time32 WINAPI iTime(const void* rates, int bars, int bar) {
    static uint build = GetTerminalBuild();               // TODO: defeats inlining
-   if (!build || bar < 0 || bar >= bars) return(NULL);
+   if (!build || bar < 0 || bar >= bars) return NULL;
 
    time32 time;
    uint shift = bars-1-bar;
    if (build <= 509) time = ((HistoryBar400*) rates)[shift].time;
    else              time = ((HistoryBar401*) rates)[shift].time;
-   return(time);
+   return time;
 }

--- a/header/struct/mt4/HistoryBar401.h
+++ b/header/struct/mt4/HistoryBar401.h
@@ -8,19 +8,29 @@
  *
  * Bar format in history files of terminal builds > 509, and internal bar format of ArrayCopyRates().
  *
- * @see  https://docs.mql4.com/mql4changes
+ * @see  https://docs.mql4.com/mql4changes# [partially inaccurate]
  */
 struct HISTORY_BAR_401 {                        // -- offset --- size --- description -----------
-   time32 time;                                 //         0        4     low int32 of int64
-   DWORD  _reserved1;                           //         4        4     high int32 of int64
+   union {                                      //         0        8     opentime
+      struct {                                  //
+         time32 time;                           //         0        4     32-bit datetime value
+         DWORD  reserved1;                      //         4        4     high 32 bits
+      };                                        //
+      time64 time_ex;                           //         0        8     64-bit datetime value
+   };                                           //
    double open;                                 //         8        8
    double high;                                 //        16        8
    double low;                                  //        24        8
    double close;                                //        32        8
-   uint   ticks;                                //        40        4     low int32 of int64
-   DWORD  _reserved2;                           //        44        4     high int32 of int64
+   union {                                      //        40        8
+      struct {                                  //
+         uint  ticks;                           //        40        4      low 32 bits
+         DWORD reserved2;                       //        44        4      high 32 bits
+      };                                        //
+      uint64 tickVolume;                        //        40        8      full 64-bit value
+   };                                           //
    int    spread;                               //        48        4     (unused)
-   uint64 volume;                               //        52        8     (unused)
+   uint64 realVolume;                           //        52        8     (unused)
 };                                              // ----------------------------------------------
 #pragma pack(pop)                               //               = 60
 

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -8,8 +8,9 @@
 
 #include <shellapi.h>
 
-BOOL  g_cliOptionPortableMode;                              // whether cmd line option /portable is set
-DWORD g_cliDebugOptions;                                    // bit mask of specified CLI debug options
+HANDLE g_hExpanderStartThread;                              // handle of worker thread executing onExpanderStart()
+BOOL   g_cliOptionPortableMode;                             // whether cmd line option /portable is set
+DWORD  g_cliDebugOptions;                                   // bit mask of specified CLI debug options
 
 extern MqlInstanceList               g_mqlInstances;        // all MQL program instances
 extern std::vector<DWORD>            g_threads;             // all known threads executing MQL programs
@@ -89,9 +90,8 @@ BOOL WINAPI onProcessAttach() {
    LocalFree(argv);
 
    // launch independant worker thread for custom initializations
-   HANDLE hThread = CreateThread(NULL, 0, onExpanderStart, NULL, 0, NULL);
-   if (hThread) CloseHandle(hThread);
-   else         error(ERR_WIN32_ERROR + GetLastError(), "CreateThread()");    // report error but don't fail
+   g_hExpanderStartThread = CreateThread(NULL, 0, onExpanderStart, NULL, 0, NULL);
+   if (!g_hExpanderStartThread) error(ERR_WIN32_ERROR + GetLastError(), "CreateThread()");    // report error but don't fail
 
    return TRUE;
 }
@@ -105,6 +105,11 @@ BOOL WINAPI onProcessAttach() {
  * @return BOOL - success status
  */
 BOOL WINAPI onProcessDetach(BOOL isTerminating) {
+   if (g_hExpanderStartThread) {                   // debug builds may be unloaded while onExpanderStart() is still running
+      WaitForSingleObject(g_hExpanderStartThread, INFINITE);
+      CloseHandle(g_hExpanderStartThread);
+      g_hExpanderStartThread = NULL;
+   }
    if (!isTerminating) {
       DeleteCriticalSection(&g_expanderMutex);
       ReleaseTickTimers();

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1,4 +1,5 @@
 #include "expander.h"
+#include "dllmain.h"
 #include "lib/helper.h"
 #include "lib/string.h"
 #include "lib/terminal.h"
@@ -17,24 +18,6 @@ extern std::vector<TICK_TIMER_DATA*> g_tickTimers;          // all registered ti
 extern CRITICAL_SECTION              g_expanderMutex;       // mutex for Expander-wide locking
 
 
-//
-// Win32 Mutex            = system-wide mutex
-// Win32 CRITICAL_SECTION = process-wide mutex
-// https://docs.microsoft.com/en-us/windows/desktop/Sync/critical-section-objects
-//
-// Speed benchmark and especially: ...if the spin count expires, the mutex for the critical section will be allocated.
-// https://stackoverflow.com/questions/800383/what-is-the-difference-between-mutex-and-critical-section
-//
-// Exception safety:
-// http://progblogs.blogspot.com/2012/02/critical-section-vs-mutex.html
-//
-
-
-// forward declarations
-BOOL WINAPI onProcessAttach();
-BOOL WINAPI onProcessDetach(BOOL isTerminating);
-
-
 /**
  * DLL entry point.
  *
@@ -46,10 +29,13 @@ BOOL WINAPI onProcessDetach(BOOL isTerminating);
  */
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID reserved) {
    switch (reason) {
-      case DLL_PROCESS_ATTACH: onProcessAttach();               break;
-      case DLL_THREAD_ATTACH :                                  break;
-      case DLL_THREAD_DETACH :                                  break;
-      case DLL_PROCESS_DETACH: onProcessDetach((BOOL)reserved); break;
+      case DLL_PROCESS_ATTACH:
+         DisableThreadLibraryCalls(hModule);
+         return onProcessAttach();
+
+      case DLL_PROCESS_DETACH:
+         onProcessDetach((BOOL)reserved);
+         break;
    }
    return TRUE;
 }
@@ -57,28 +43,27 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID reserved) {
 
 /**
  * Handler for DLL_PROCESS_ATTACH events.
+ * Code in this function must be safe under DLL loader lock.
  *
- * @return BOOL
+ * @return BOOL - success status
  */
 BOOL WINAPI onProcessAttach() {
-   g_mqlInstances   .reserve(128);
-   g_threads        .reserve(512);
-   g_threadsPrograms.reserve(512);
-   g_tickTimers     .reserve(32);
-
    InitializeCriticalSection(&g_expanderMutex);
 
-   // parse command line arguments
+   g_mqlInstances.   reserve(128);                    // TODO: replace global state by getter/setter functions
+   g_threads.        reserve(512);
+   g_threadsPrograms.reserve(512);
+   g_tickTimers.     reserve(32);
+
+   // parse command line arguments                    // TODO: replace global state by lazy-initialized getters
    int argc;
    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-   if (!argv) return !error(ERR_WIN32_ERROR+GetLastError(), "CommandLineToArgvW()");
+   if (!argv) return !error(ERR_WIN32_ERROR + GetLastError(), "CommandLineToArgvW()");
 
    for (int i=1; i < argc; i++) {
-      if (StrStartsWith(argv[i], L"/portable")) {
-         // The terminal also enables portable mode if a command line parameter just *starts* with prefix "/portable".
-         // For example passing parameter "/portablepoo" enables portable mode, too. This test mirrors that behavior.
-         g_cliOptionPortableMode = TRUE;
-         continue;
+      if (StrStartsWith(argv[i], L"/portable")) {     // The terminal accepts any argument starting with prefix "/portable",
+         g_cliOptionPortableMode = TRUE;              // e.g. "/portable-poo" activates portable mode, too.
+         continue;                                    // This test mirrors that unusual behavior.
       }
       if (StrCompare(argv[i], L"/rsf:debug-ec")) {
          g_cliDebugOptions |= DEBUG_EXECUTION_CONTEXT;
@@ -103,12 +88,11 @@ BOOL WINAPI onProcessAttach() {
    }
    LocalFree(argv);
 
-   // lock the production version of the DLL in memory
-   const char* dllName = GetExpanderFileNameA();
-   if (StrEndsWithI(dllName, "rsfMT4Expander.dll")) {
-      HMODULE hModule = NULL;
-      GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_PIN, (LPCTSTR)onProcessAttach, &hModule);
-   }
+   // launch independant worker thread for custom initializations
+   HANDLE hThread = CreateThread(NULL, 0, onExpanderStart, NULL, 0, NULL);
+   if (!hThread) return !error(ERR_WIN32_ERROR + GetLastError(), "CreateThread()");
+   CloseHandle(hThread);
+
    return TRUE;
 }
 
@@ -116,9 +100,9 @@ BOOL WINAPI onProcessAttach() {
 /**
  * Handler for DLL_PROCESS_DETACH events.
  *
- * @param  BOOL isTerminating - whether the DLL is detached because the process is terminating
+ * @param  BOOL isTerminating - whether the DLL is detached because of process termination
  *
- * @return BOOL
+ * @return BOOL - success status
  */
 BOOL WINAPI onProcessDetach(BOOL isTerminating) {
    if (!isTerminating) {
@@ -127,4 +111,29 @@ BOOL WINAPI onProcessDetach(BOOL isTerminating) {
       ReleaseWindowProperties();
    }
    return TRUE;
+}
+
+
+/**
+ * Executes start tasks outside of the DLL loader lock (runs in a separate thread).
+ * These are independant tasks not required for a working DLL.
+ *
+ * @param  void* lpParam - thread data passed by CreateThread()
+ *
+ * @return DWORD - error status
+ */
+DWORD WINAPI onExpanderStart(void* lpParam) {
+   // lock the DLL in memory (production only, debug is immediately released for testing)
+   const wchar* dllName = GetExpanderFileNameW();
+   BOOL isProduction = StrEndsWithI(dllName, L"rsfMT4Expander.dll");
+   if (isProduction) {
+      HMODULE hModule = NULL;
+      GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_PIN, (LPCTSTR)onProcessAttach, &hModule);
+   }
+
+   // customize the terminal (production only as customization will subclass MT4 windows)
+   if (isProduction) {
+      CustomizeTerminal();
+   }
+   return NO_ERROR;
 }

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -90,8 +90,8 @@ BOOL WINAPI onProcessAttach() {
 
    // launch independant worker thread for custom initializations
    HANDLE hThread = CreateThread(NULL, 0, onExpanderStart, NULL, 0, NULL);
-   if (!hThread) return !error(ERR_WIN32_ERROR + GetLastError(), "CreateThread()");
-   CloseHandle(hThread);
+   if (hThread) CloseHandle(hThread);
+   else         error(ERR_WIN32_ERROR + GetLastError(), "CreateThread()");    // report error but don't fail
 
    return TRUE;
 }

--- a/src/expander.cpp
+++ b/src/expander.cpp
@@ -267,3 +267,13 @@ char   __cdecl _char  (char   value, ...) { return value; }
 int    __cdecl _int   (int    value, ...) { return value; }
 float  __cdecl _float (float  value, ...) { return value; }
 double __cdecl _double(double value, ...) { return value; }
+
+
+/**
+ * A no-op for explicitly loading the Expander from MQL. If the MQL framework is used it will implicitly
+ * load the Expander during MQL program initialization.
+ */
+void WINAPI LoadMT4Expander() {
+   // nothing to do here
+   #pragma EXPANDER_EXPORT
+}

--- a/src/lib/datetime.cpp
+++ b/src/lib/datetime.cpp
@@ -1071,7 +1071,7 @@ BOOL WINAPI GetTimeZoneInfoByWindowsNameA(TIME_ZONE_INFORMATION* tzi, const char
       SYSTEMTIME DaylightDate;
    };
 
-   // a local function as C++98 substitute for a lambda function
+   // a local function as substitute for missing lambda support in C++03
    struct local {
       static BOOL ReadRegistryValue(HKEY hKey, string &key, wchar* value, DWORD type, void* buffer, DWORD size) {
          int error = RegGetValueW(hKey, NULL, value, type, NULL, buffer, &size);

--- a/src/lib/executioncontext.cpp
+++ b/src/lib/executioncontext.cpp
@@ -1295,7 +1295,7 @@ uint WINAPI GetCurrentThreadIndex() {
    // look-up the current thread
    uint size = g_threads.size();
    for (uint i=0; i < size; i++) {
-      if (g_threads[i] == currentThread) return(i);               // thread found
+      if (g_threads[i] == currentThread) return i;                // thread found
    }
 
    // thread not found
@@ -1303,13 +1303,15 @@ uint WINAPI GetCurrentThreadIndex() {
       debug("waiting for lock on: g_expanderMutex...");
       EnterCriticalSection(&g_expanderMutex);
    }
-   g_threads        .push_back(currentThread);                    // add current thread to the list
+   g_threads.push_back(currentThread);                            // add current thread to the list
    g_threadsPrograms.push_back(0);                                // add empty program index of 0 (zero) to the list
    uint index = g_threads.size() - 1;
    LeaveCriticalSection(&g_expanderMutex);
 
-   if (index > 768 && !(index % 100)) debug("added thread %d to thread list (size=%d)", currentThread, index+1);
-   return(index);
+   if (index > 768 && !(index % 100)) {
+      debug("added thread %d to thread list (size=%d)", currentThread, index+1);
+   }
+   return index;
 }
 
 
@@ -1320,9 +1322,10 @@ uint WINAPI GetCurrentThreadIndex() {
  */
 uint WINAPI GetLastThreadProgram() {
    uint index = GetCurrentThreadIndex();
-   if (g_threadsPrograms.size() > index)
-      return(g_threadsPrograms[index]);
-   return(NULL);
+   if (g_threadsPrograms.size() > index) {
+      return g_threadsPrograms[index];
+   }
+   return NULL;
 }
 
 

--- a/src/lib/file.cpp
+++ b/src/lib/file.cpp
@@ -331,17 +331,17 @@ const char* WINAPI GetReparsePointTargetA(const char* name) {
    // read the reparse data
    if (IsReparseTagMicrosoft(rdata->ReparseTag)) {
       if (rdata->ReparseTag == IO_REPARSE_TAG_MOUNT_POINT) {
-         uint   offset = rdata->MountPointReparseBuffer.SubstituteNameOffset >> 1;
-         uint   len    = rdata->MountPointReparseBuffer.SubstituteNameLength >> 1;
-         string target = utf16ToAnsi(wstring(&rdata->MountPointReparseBuffer.PathBuffer[offset], len));
+         uint   offset = rdata->MountPoint.SubstituteNameOffset >> 1;
+         uint   len    = rdata->MountPoint.SubstituteNameLength >> 1;
+         string target = utf16ToAnsi(wstring(&rdata->MountPoint.PathBuffer[offset], len));
          result = sdup(target.c_str() + strlen("\\??\\"));
       }
       else if (rdata->ReparseTag == IO_REPARSE_TAG_SYMLINK) {
-         uint   offset = rdata->SymbolicLinkReparseBuffer.SubstituteNameOffset >> 1;
-         uint   len    = rdata->SymbolicLinkReparseBuffer.SubstituteNameLength >> 1;
-         string target = utf16ToAnsi(wstring(&rdata->SymbolicLinkReparseBuffer.PathBuffer[offset], len));
+         uint   offset = rdata->SymbolicLink.SubstituteNameOffset >> 1;
+         uint   len    = rdata->SymbolicLink.SubstituteNameLength >> 1;
+         string target = utf16ToAnsi(wstring(&rdata->SymbolicLink.PathBuffer[offset], len));
 
-         BOOL isRelative = rdata->SymbolicLinkReparseBuffer.Flags & SYMLINK_FLAG_RELATIVE;
+         BOOL isRelative = rdata->SymbolicLink.Flags & SYMLINK_FLAG_RELATIVE;
          if (isRelative) {
             char drive[MAX_DRIVE], dir[MAX_DIR];
             _splitpath(name, drive, dir, NULL, NULL);

--- a/src/lib/helper.cpp
+++ b/src/lib/helper.cpp
@@ -230,13 +230,11 @@ BOOL WINAPI IsVirtualKeyDown(int key) {
 
 
 /**
- * Return the flags of all currently pressed virtual keys.
+ * Return the flags of currently pressed virtual keys.
  *
- * @param  DWORD flags [optional] - combination of virtual-key flags (default: all flags)
+ * @param  DWORD flags [optional] - virtual keys to test for (default: all keys defined in F_VK_ALL)
  *
  * @return DWORD
- *
- * @see  "header/shared/defines.h"
  */
 DWORD WINAPI GetPressedVirtualKeys(DWORD flags = F_VK_ALL) {
    DWORD pressed = 0;
@@ -288,16 +286,17 @@ BOOL WINAPI IsUIThread(DWORD threadId/*=NULL*/) {
 
 
 /**
- * Gibt die ID des Userinterface-Threads zur�ck.
+ * Return the id of the UI thread.
  *
- * @return DWORD - Thread-ID (nicht das Thread-Handle) oder 0, falls ein Fehler auftrat
+ * @return DWORD - thread id (not thread handle) or NULL in case of errors
  */
 DWORD WINAPI GetUIThreadId() {
    static DWORD uiThreadId;
 
    if (!uiThreadId) {
       if (HWND hWnd = GetTerminalMainWindow()) {
-         uiThreadId = GetWindowThreadProcessId(hWnd, NULL);
+         DWORD threadId = GetWindowThreadProcessId(hWnd, NULL);
+         if (!uiThreadId) uiThreadId = threadId;      // another thread may have been faster
       }
    }
    return(uiThreadId);

--- a/src/lib/string.cpp
+++ b/src/lib/string.cpp
@@ -839,7 +839,7 @@ wchar* WINAPI ansiToUtf16(const char* str) {
  * @return wstring - UTF-16 string or an empty string in case of errors
  */
 wstring WINAPI ansiToUtf16(const string &str) {
-   int length = static_cast<int>(str.length());
+   int length = (int)str.length();
    if (!length) return wstring();
 
    DWORD flags = MB_ERR_INVALID_CHARS;
@@ -933,7 +933,7 @@ wchar* WINAPI utf8ToUtf16(const char* str) {
  * @return wstring - UTF-16 string or an empty string in case of errors
  */
 wstring WINAPI utf8ToUtf16(const string &str) {
-   int length = static_cast<int>(str.length());
+   int length = (int)str.length();
    if (!length) return wstring();
 
    DWORD flags = MB_ERR_INVALID_CHARS;
@@ -986,7 +986,7 @@ char* WINAPI utf16ToAnsi(const wchar* wstr) {
  * @return string - ANSI string or an empty string in case of errors
  */
 string WINAPI utf16ToAnsi(const wstring &wstr) {
-   int length = static_cast<int>(wstr.length());
+   int length = (int)wstr.length();
    if (!length) return string();
 
    DWORD flags = WC_NO_BEST_FIT_CHARS;
@@ -1038,7 +1038,7 @@ char* WINAPI utf16ToUtf8(const wchar* wstr) {
  * @return string - UTF-8 string or an empty string in case of errors
  */
 string WINAPI utf16ToUtf8(const wstring &wstr) {
-   int length = static_cast<int>(wstr.length());
+   int length = (int)wstr.length();
    if (!length) return string();
 
    DWORD flags = WC_ERR_INVALID_CHARS;

--- a/src/lib/string.cpp
+++ b/src/lib/string.cpp
@@ -353,17 +353,18 @@ BOOL WINAPI StrEndsWithI(const char* str, const char* suffix) {
  * @return BOOL
  */
 BOOL WINAPI StrEndsWith(const wchar* str, const wchar* suffix) {
-   if (!str)          return(FALSE);
-   if (!suffix)       return(!error(ERR_INVALID_PARAMETER, "invalid parameter suffix: %S", suffix));
-   if (str == suffix) return(TRUE);       // if pointers are equal values are too
+   if (!str)          return FALSE;
+   if (!suffix)       return !error(ERR_INVALID_PARAMETER, "invalid parameter suffix: %S", suffix);
+   if (str == suffix) return TRUE;        // if pointers are equal values are too
 
    uint strLen    = wstrlen(str);
    uint suffixLen = wstrlen(suffix);
-   if (!suffixLen) return(!error(ERR_INVALID_PARAMETER, "invalid parameter suffix: \"\""));
+   if (!suffixLen) return !error(ERR_INVALID_PARAMETER, "invalid parameter suffix: \"\"");
 
-   if (strLen >= suffixLen)
-      return(wstrcmp(str + strLen - suffixLen, suffix) == 0);
-   return(FALSE);
+   if (strLen >= suffixLen) {
+      return (wstrcmp(str + strLen - suffixLen, suffix) == 0);
+   }
+   return FALSE;
 }
 
 
@@ -376,17 +377,18 @@ BOOL WINAPI StrEndsWith(const wchar* str, const wchar* suffix) {
  * @return BOOL
  */
 BOOL WINAPI StrEndsWithI(const wchar* str, const wchar* suffix) {
-   if (!str)          return(FALSE);
-   if (!suffix)       return(!error(ERR_INVALID_PARAMETER, "invalid parameter suffix: %S", suffix));
-   if (str == suffix) return(TRUE);       // if pointers are equal values are too
+   if (!str)          return FALSE;
+   if (!suffix)       return !error(ERR_INVALID_PARAMETER, "invalid parameter suffix: %S", suffix);
+   if (str == suffix) return TRUE;        // if pointers are equal values are too
 
    uint strLen    = wstrlen(str);
    uint suffixLen = wstrlen(suffix);
-   if (!suffixLen) return(!error(ERR_INVALID_PARAMETER, "invalid parameter suffix: \"\""));
+   if (!suffixLen) return !error(ERR_INVALID_PARAMETER, "invalid parameter suffix: \"\"");
 
-   if (strLen >= suffixLen)
-      return(wstricmp(str + strLen - suffixLen, suffix) == 0);
-   return(FALSE);
+   if (strLen >= suffixLen) {
+      return (wstricmp(str + strLen - suffixLen, suffix) == 0);
+   }
+   return FALSE;
 }
 
 

--- a/src/lib/terminal.cpp
+++ b/src/lib/terminal.cpp
@@ -9,10 +9,60 @@
 
 #include <shlobj.h>
 
-extern BOOL  g_cliOptionPortableMode;                    // whether cmd line option /portable is set
+extern BOOL g_cliOptionPortableMode;                     // whether cmd line option /portable is set
 
 extern "C" IMAGE_DOS_HEADER          __ImageBase;        // this DLL's module handle
 #define HMODULE_EXPANDER ((HMODULE) &__ImageBase)
+
+
+/**
+ * Customize the terminal's UI.
+ */
+void WINAPI CustomizeTerminal() {
+   // get the terminal main window
+   HWND hWnd = GetTerminalMainWindow();
+   if (!hWnd) return;
+
+   // get the toolbar
+   HWND hToolbar = GetDlgItem(hWnd, IDC_TOOLBAR);
+   if (!hToolbar) {
+      error(ERR_WIN32_ERROR + GetLastError(), "GetDlgItem(MainWindow, IDC_TOOLBAR) => NULL (terminal toolbar not found)");
+      return;
+   }
+
+   // a local function as substitute for missing lambda support in C++03
+   struct local {
+      static void CloseWindow(HWND hCtrl, BOOL onUIThread) {
+         if (onUIThread) {
+            DestroyWindow(hCtrl);
+         }
+         else {
+            PostMessageA(hCtrl, WM_CLOSE, 0, 0);
+            while (IsWindow(hCtrl)) Sleep(100);
+         }
+      }
+   };
+
+   // whether we are executed by the UI thread
+   BOOL onUIThread = (GetCurrentThreadId() == GetWindowThreadProcessId(hToolbar, NULL));
+
+   // find and remove a search box control (contains the community button)
+   HWND hSearchCtrl = GetDlgItem(hToolbar, IDC_TOOLBAR_SEARCHBOX);
+   if (hSearchCtrl) {
+      local::CloseWindow(hSearchCtrl, onUIThread);
+      if (!RedrawWindow(hToolbar, NULL, NULL, RDW_ERASE|RDW_INVALIDATE)) {
+         error(ERR_WIN32_ERROR + GetLastError(), "RedrawWindow(IDC_TOOLBAR) failed");
+         return;
+      }
+   }
+   else {
+      // if search box control not found, find/remove an independent community button
+      if (HWND hBtnCtrl = GetDlgItem(hToolbar, IDC_TOOLBAR_COMMUNITY_BUTTON)) {
+         local::CloseWindow(hBtnCtrl, onUIThread);
+      }
+   }
+   #pragma EXPANDER_EXPORT
+}
 
 
 /**
@@ -162,7 +212,7 @@ const char* WINAPI GetExpanderFileNameA() {
 
       char* tmp = utf16ToAnsi(wname);
       if (!filename) filename = tmp;
-      else free(tmp);                  // another thread may have been faster
+      else free(tmp);                        // another thread may have been faster
    }
    return filename;
    #pragma EXPANDER_EXPORT
@@ -179,19 +229,19 @@ const wchar* WINAPI GetExpanderFileNameW() {
 
    if (!filename) {
       wchar* buffer = NULL;
-      uint size=MAX_PATH >> 1, length=size;
+      uint size = MAX_PATH >> 1, length = size;
       while (length >= size) {
          size <<= 1;
          buffer = (wchar*) alloca(size * sizeof(wchar));
          length = GetModuleFileNameW(HMODULE_EXPANDER, buffer, size);   // may return a path longer than MAX_PATH
       }
-      if (!length) return((wchar*)!error(ERR_WIN32_ERROR+GetLastError(), "GetModuleFileNameW()"));
+      if (!length) return (wchar*)!error(ERR_WIN32_ERROR + GetLastError(), "GetModuleFileNameW()");
 
       wchar* tmp = wsdup(buffer);
       if (!filename) filename = tmp;
-      else free(tmp);                     // another thread may have been faster
+      else free(tmp);                        // another thread may have been faster
    }
-   return(filename);
+   return filename;
    #pragma EXPANDER_EXPORT
 }
 
@@ -559,25 +609,24 @@ HWND WINAPI GetTerminalMainWindow() {
    if (!hWndMain) {
       DWORD processId, self = GetCurrentProcessId();
       uint  size = 255;
-      char* className = (char*) alloca(size);                        // on the stack: buffer for window class name
+      char* className = (char*) alloca(size);      // on the stack
 
       HWND hWndNext = GetTopWindow(NULL);
-
-      while (hWndNext) {                                             // iterate over all top-level windows
+      while (hWndNext) {                           // iterate over all top-level windows
          GetWindowThreadProcessId(hWndNext, &processId);
          if (processId == self) {
-            if (!GetClassNameA(hWndNext, className, size)) return((HWND)!error(ERR_WIN32_ERROR+GetLastError(), "GetClassNameA()"));
+            if (!GetClassNameA(hWndNext, className, size)) return (HWND)!error(ERR_WIN32_ERROR + GetLastError(), "GetClassNameA()");
             if (StrCompare(className, "MetaQuotes::MetaTrader::4.00")) {
                break;
             }
          }
          hWndNext = GetWindow(hWndNext, GW_HWNDNEXT);
       }
-      if (!hWndNext) return((HWND)!error(ERR_WIN32_ERROR+GetLastError(), "cannot find terminal main window"));
+      if (!hWndNext) return (HWND)!error(ERR_RUNTIME_ERROR, "cannot find terminal main window");
 
-      hWndMain = hWndNext;
+      if (!hWndMain) hWndMain = hWndNext;          // another thread may have been faster
    }
-   return(hWndMain);
+   return hWndMain;
    #pragma EXPANDER_EXPORT
 }
 

--- a/src/lib/terminal.cpp
+++ b/src/lib/terminal.cpp
@@ -61,7 +61,6 @@ void WINAPI CustomizeTerminal() {
          local::CloseWindow(hBtnCtrl, onUIThread);
       }
    }
-   #pragma EXPANDER_EXPORT
 }
 
 


### PR DESCRIPTION
- move the MQL implementation of script `CustomizeTerminal()` to the DLL
- launch `CustomizeTerminal()` from `DllMain()`
- add explicit export `LoadMT4Expander()` as a no-op

Also contains some additional unrelated code style updates.

@codex review