### PR TITLE
Remove parsing of CLI arguments from DllMain()

### DIFF
--- a/header/lib/terminal.h
+++ b/header/lib/terminal.h
@@ -3,6 +3,8 @@
 
 
 void         WINAPI CustomizeTerminal();
+DWORD        WINAPI GetCliOptions();
+BOOL         WINAPI IsCliOption(DWORD flag);
 char*        WINAPI FindHistoryDirectoryA(const char* filename, BOOL removeFile);
 HWND         WINAPI FindInputDialogA(ProgramType programType, const char* programName);
 const char*  WINAPI GetExpanderFileNameA();

--- a/header/shared/bak/defines.h
+++ b/header/shared/bak/defines.h
@@ -106,12 +106,13 @@
 #define UNINITREASON_CLOSE          REASON_CLOSE
 
 
-// CLI debug options (flags)
-#define DEBUG_EXECUTION_CONTEXT                 1           // whether cmd line option /rsf:debug-ec is set
-#define DEBUG_ACCOUNT_SERVER                    2           // whether cmd line option /rsf:debug-accountserver is set
-#define DEBUG_ACCOUNT_NUMBER                    4           // whether cmd line option /rsf:debug-accountnumber is set
-#define DEBUG_OBJECT_CREATE                     8           // whether cmd line option /rsf:debug-objectcreate is set
-#define DEBUG_INDICATOR_LIST                   16           // whether cmd line option /rsf:debug-indicatorlist is set
+// flags for command line options of "terminal.exe"
+#define OPTION_PORTABLE_MODE                    1        // option "/portable"
+#define OPTION_DEBUG_ACCOUNT_NUMBER             2        // option "/rsf:debug-accountnumber"
+#define OPTION_DEBUG_ACCOUNT_SERVER             4        // option "/rsf:debug-accountserver"
+#define OPTION_DEBUG_EXECUTION_CONTEXT          8        // option "/rsf:debug-ec"
+#define OPTION_DEBUG_INDICATOR_LIST            16        // option "/rsf:debug-indicatorlist"
+#define OPTION_DEBUG_OBJECT_CREATE             32        // option "/rsf:debug-objectcreate"
 
 
 // window property names

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -6,11 +6,7 @@
 #include "lib/timer.h"
 #include "struct/ExecutionContext.h"
 
-#include <shellapi.h>
-
-HANDLE g_hExpanderStartThread;                              // handle of worker thread executing onExpanderStart()
-BOOL   g_cliOptionPortableMode;                             // whether cmd line option /portable is set
-DWORD  g_cliDebugOptions;                                   // bit mask of specified CLI debug options
+HANDLE g_hExpanderStartThread;                              // handle of the thread executing onExpanderStart()
 
 extern MqlInstanceList               g_mqlInstances;        // all MQL program instances
 extern std::vector<DWORD>            g_threads;             // all known threads executing MQL programs
@@ -44,7 +40,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID reserved) {
 
 /**
  * Handler for DLL_PROCESS_ATTACH events.
- * Code in this function must be safe under DLL loader lock.
+ * Code in this function must be safe under the DLL loader-lock.
  *
  * @return BOOL - success status
  */
@@ -55,39 +51,6 @@ BOOL WINAPI onProcessAttach() {
    g_threads.        reserve(512);
    g_threadsPrograms.reserve(512);
    g_tickTimers.     reserve(32);
-
-   // parse command line arguments                    // TODO: replace global state by lazy-initialized getters
-   int argc;
-   LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-   if (!argv) return !error(ERR_WIN32_ERROR + GetLastError(), "CommandLineToArgvW()");
-
-   for (int i=1; i < argc; i++) {
-      if (StrStartsWith(argv[i], L"/portable")) {     // The terminal accepts any argument starting with prefix "/portable",
-         g_cliOptionPortableMode = TRUE;              // e.g. "/portable-poo" activates portable mode, too.
-         continue;                                    // This test mirrors that unusual behavior.
-      }
-      if (StrCompare(argv[i], L"/rsf:debug-ec")) {
-         g_cliDebugOptions |= DEBUG_EXECUTION_CONTEXT;
-         continue;
-      }
-      if (StrCompare(argv[i], L"/rsf:debug-accountnumber")) {
-         g_cliDebugOptions |= DEBUG_ACCOUNT_NUMBER;
-         continue;
-      }
-      if (StrCompare(argv[i], L"/rsf:debug-accountserver")) {
-         g_cliDebugOptions |= DEBUG_ACCOUNT_SERVER;
-         continue;
-      }
-      if (StrCompare(argv[i], L"/rsf:debug-objectcreate")) {
-         g_cliDebugOptions |= DEBUG_OBJECT_CREATE;
-         continue;
-      }
-      if (StrCompare(argv[i], L"/rsf:debug-indicatorlist")) {
-         g_cliDebugOptions |= DEBUG_INDICATOR_LIST;
-         continue;
-      }
-   }
-   LocalFree(argv);
 
    // launch independant worker thread for custom initializations
    g_hExpanderStartThread = CreateThread(NULL, 0, onExpanderStart, NULL, 0, NULL);

--- a/src/lib/executioncontext.cpp
+++ b/src/lib/executioncontext.cpp
@@ -16,7 +16,6 @@ std::vector<DWORD> g_threads;                      // all known threads executin
 std::vector<uint>  g_threadsPrograms;              // pid of the last MQL program executed by a thread
 uint               g_lastUIThreadProgram;          // pid of the last MQL program executed by the UI thread
 CRITICAL_SECTION   g_expanderMutex;                // mutex for Expander-wide locking
-extern DWORD       g_cliDebugOptions;              // bit mask of specified CLI debug options
 
 struct RECOMPILED_MODULE {                         // A struct holding the last MQL module with UninitReason UR_RECOMPILE.
    uint       pid;                                 // Only one module is tracked (the last one) and the variable is accessed
@@ -323,7 +322,9 @@ int WINAPI SyncMainContext_init(EXECUTION_CONTEXT* ec, ProgramType programType, 
    if ((uint)accountServer < MIN_VALID_POINTER)        return(error(ERR_INVALID_PARAMETER, "invalid parameter accountServer: 0x%p (not a valid pointer)", accountServer));
    if (ec->pid) SetLastThreadProgram(ec->pid);                             // set the thread's currently executed program asap (error handling)
 
-   if (g_cliDebugOptions & DEBUG_EXECUTION_CONTEXT) debug("  i:%p  %-17s  %-14s  ec=%s", ec, programName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
+   static DWORD cliOptions = MAXDWORD;
+   if (cliOptions == MAXDWORD) cliOptions = GetCliOptions();
+   if (cliOptions & OPTION_DEBUG_EXECUTION_CONTEXT) debug("  i:%p  %-17s  %-14s  ec=%s", ec, programName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
 
    uint currentPid = ec->pid;
    BOOL isPid      = (currentPid);
@@ -458,7 +459,7 @@ int WINAPI SyncMainContext_init(EXECUTION_CONTEXT* ec, ProgramType programType, 
    ec_SetLoglevelMail    (ec, ecRef->loglevelMail    );
    ec_SetLoglevelTelegram(ec, ecRef->loglevelTelegram);
    ec_SetLogFilename     (ec, ecRef->logFilename     );
-   ec_SetDebugOptions(ec, g_cliDebugOptions);
+   ec_SetDebugOptions    (ec, cliOptions);
 
    // TODO: reset errors if not in an init() call from start()
    //ec->dllErrorMsg   = NULL;
@@ -491,7 +492,7 @@ int WINAPI SyncMainContext_init(EXECUTION_CONTEXT* ec, ProgramType programType, 
       AddToIndicatorList(ec);
    }
 
-   if (g_cliDebugOptions & DEBUG_EXECUTION_CONTEXT) debug("  o:%p  %-17s  %-14s  ec=%s", ec, programName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
+   if (cliOptions & OPTION_DEBUG_EXECUTION_CONTEXT) debug("  o:%p  %-17s  %-14s  ec=%s", ec, programName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
    return(NO_ERROR);
    #pragma EXPANDER_EXPORT
 }
@@ -575,7 +576,9 @@ int WINAPI SyncMainContext_deinit(EXECUTION_CONTEXT* ec, UninitializeReason unin
    if (!ec->pid)                     return(error(ERR_INVALID_PARAMETER, "invalid execution context (ec.pid=0):  uninitReason=%s  thread=%d %s  ec=%s", UninitReasonToStr(uninitReason), GetCurrentThreadId(), (IsUIThread() ? "(UI)":"(non-UI)"), EXECUTION_CONTEXT_toStr(ec)));
    SetLastThreadProgram(ec->pid);                                    // set the thread's currently executed program asap (error handling)
 
-   if (g_cliDebugOptions & DEBUG_EXECUTION_CONTEXT) debug("i:%p  %-17s  %-14s  ec=%s", ec, ec->programName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
+   static DWORD cliOptions = MAXDWORD;
+   if (cliOptions == MAXDWORD) cliOptions = GetCliOptions();
+   if (cliOptions & OPTION_DEBUG_EXECUTION_CONTEXT) debug("i:%p  %-17s  %-14s  ec=%s", ec, ec->programName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
 
    ContextChain &chain = *g_mqlInstances[ec->pid];
    uint chainSize = chain.size();
@@ -597,7 +600,7 @@ int WINAPI SyncMainContext_deinit(EXECUTION_CONTEXT* ec, UninitializeReason unin
       else warn(ERR_ILLEGAL_STATE, "no module context found at chain[%d]: %p  main=%s", i, chain[i], EXECUTION_CONTEXT_toStr(ec));
    }
 
-   if (g_cliDebugOptions & DEBUG_EXECUTION_CONTEXT) debug("o:%p  %-17s  %-14s  ec=%s", ec, ec->programName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
+   if (cliOptions & OPTION_DEBUG_EXECUTION_CONTEXT) debug("o:%p  %-17s  %-14s  ec=%s", ec, ec->programName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
    return(NO_ERROR);
    #pragma EXPANDER_EXPORT
 }
@@ -631,7 +634,9 @@ int WINAPI SyncLibContext_init(EXECUTION_CONTEXT* ec, UninitializeReason uninitR
    if ((int)digits < 0)                              return(error(ERR_INVALID_PARAMETER, "invalid parameter digits: %d", (int)digits));
    if (point <= 0)                                   return(error(ERR_INVALID_PARAMETER, "invalid parameter point: %f", point));
 
-   if (g_cliDebugOptions & DEBUG_EXECUTION_CONTEXT) debug("   i:%p  %-17s  %-14s  ec=%s", ec, moduleName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
+   static DWORD cliOptions = MAXDWORD;
+   if (cliOptions == MAXDWORD) cliOptions = GetCliOptions();
+   if (cliOptions & OPTION_DEBUG_EXECUTION_CONTEXT) debug("   i:%p  %-17s  %-14s  ec=%s", ec, moduleName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
 
    // fix the UninitializeReason
    uninitReason = FixUninitReason(ec, MT_LIBRARY, CF_INIT, uninitReason);
@@ -715,7 +720,7 @@ int WINAPI SyncLibContext_init(EXECUTION_CONTEXT* ec, UninitializeReason uninitR
 
                master->testing      = TRUE;                          // TODO: so wrong, we can be online and not in tester
                master->optimization = isOptimization;
-               master->debugOptions = g_cliDebugOptions;
+               master->debugOptions = cliOptions;
             }
 
             *ec = *master;                                           // re-initialize empty library context with partial master context
@@ -864,7 +869,7 @@ int WINAPI SyncLibContext_init(EXECUTION_CONTEXT* ec, UninitializeReason uninitR
          master->threadId     = g_threads[threadIndex];
          master->testing      = TRUE;
          master->optimization = isOptimization;
-         master->debugOptions = g_cliDebugOptions;
+         master->debugOptions = cliOptions;
       }
 
       // re-initialize the stateful library context with the master context
@@ -882,7 +887,7 @@ int WINAPI SyncLibContext_init(EXECUTION_CONTEXT* ec, UninitializeReason uninitR
       g_mqlInstances[currentPid]->push_back(ec);                     // add library to the new test's context chain
    }
 
-   if (g_cliDebugOptions & DEBUG_EXECUTION_CONTEXT) debug("   o:%p  %-17s  %-14s  ec=%s", ec, moduleName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
+   if (cliOptions & OPTION_DEBUG_EXECUTION_CONTEXT) debug("   o:%p  %-17s  %-14s  ec=%s", ec, moduleName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
    return(NO_ERROR);
    #pragma EXPANDER_EXPORT
 }
@@ -902,7 +907,9 @@ int WINAPI SyncLibContext_deinit(EXECUTION_CONTEXT* ec, UninitializeReason unini
    if (!ec->pid)                     return(error(ERR_INVALID_PARAMETER, "invalid execution context (ec.pid=0):  uninitReason=%s  thread=%d (%s)  ec=%s", UninitReasonToStr(uninitReason), GetCurrentThreadId(), IsUIThread() ? "UI":"non-UI", EXECUTION_CONTEXT_toStr(ec)));
    SetLastThreadProgram(ec->pid);                        // set the thread's currently executed program asap (error handling)
 
-   if (g_cliDebugOptions & DEBUG_EXECUTION_CONTEXT) debug(" i:%p  %-17s  %-14s  ec=%s", ec, ec->moduleName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
+   static DWORD cliOptions = MAXDWORD;
+   if (cliOptions == MAXDWORD) cliOptions = GetCliOptions();
+   if (cliOptions & OPTION_DEBUG_EXECUTION_CONTEXT) debug(" i:%p  %-17s  %-14s  ec=%s", ec, ec->moduleName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
 
    // try to fix the UninitializeReason
    uninitReason = FixUninitReason(ec, MT_LIBRARY, CF_DEINIT, uninitReason);
@@ -921,7 +928,7 @@ int WINAPI SyncLibContext_deinit(EXECUTION_CONTEXT* ec, UninitializeReason unini
       }
    }
 
-   if (g_cliDebugOptions & DEBUG_EXECUTION_CONTEXT) debug(" o:%p  %-17s  %-14s  ec=%s", ec, ec->moduleName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
+   if (cliOptions & OPTION_DEBUG_EXECUTION_CONTEXT) debug(" o:%p  %-17s  %-14s  ec=%s", ec, ec->moduleName, UninitReasonToStr(uninitReason), EXECUTION_CONTEXT_toStr(ec));
    return(NO_ERROR);
    #pragma EXPANDER_EXPORT
 }
@@ -1827,7 +1834,9 @@ BOOL WINAPI AddToIndicatorList(EXECUTION_CONTEXT* ec) {
       indicators->push_back(ec->pid);
    }
 
-   if (g_cliDebugOptions & DEBUG_INDICATOR_LIST) debug("%-17s %-18s list=%s  ec=%s", ec->programName, InitReasonToStr(ec->programInitReason), IndicatorListToStr(*indicators), EXECUTION_CONTEXT_toStr(ec));
+   static DWORD cliOptions = MAXDWORD;
+   if (cliOptions == MAXDWORD) cliOptions = GetCliOptions();
+   if (cliOptions & OPTION_DEBUG_INDICATOR_LIST) debug("%-17s %-18s list=%s  ec=%s", ec->programName, InitReasonToStr(ec->programInitReason), IndicatorListToStr(*indicators), EXECUTION_CONTEXT_toStr(ec));
    return TRUE;
 }
 

--- a/src/lib/executioncontext.cpp
+++ b/src/lib/executioncontext.cpp
@@ -459,7 +459,7 @@ int WINAPI SyncMainContext_init(EXECUTION_CONTEXT* ec, ProgramType programType, 
    ec_SetLoglevelMail    (ec, ecRef->loglevelMail    );
    ec_SetLoglevelTelegram(ec, ecRef->loglevelTelegram);
    ec_SetLogFilename     (ec, ecRef->logFilename     );
-   ec_SetDebugOptions    (ec, cliOptions);
+   ec_SetDebugOptions    (ec, cliOptions & ~OPTION_PORTABLE_MODE);
 
    // TODO: reset errors if not in an init() call from start()
    //ec->dllErrorMsg   = NULL;
@@ -720,7 +720,7 @@ int WINAPI SyncLibContext_init(EXECUTION_CONTEXT* ec, UninitializeReason uninitR
 
                master->testing      = TRUE;                          // TODO: so wrong, we can be online and not in tester
                master->optimization = isOptimization;
-               master->debugOptions = cliOptions;
+               master->debugOptions = cliOptions & ~OPTION_PORTABLE_MODE;
             }
 
             *ec = *master;                                           // re-initialize empty library context with partial master context
@@ -869,7 +869,7 @@ int WINAPI SyncLibContext_init(EXECUTION_CONTEXT* ec, UninitializeReason uninitR
          master->threadId     = g_threads[threadIndex];
          master->testing      = TRUE;
          master->optimization = isOptimization;
-         master->debugOptions = cliOptions;
+         master->debugOptions = cliOptions & ~OPTION_PORTABLE_MODE;
       }
 
       // re-initialize the stateful library context with the master context

--- a/src/lib/terminal.cpp
+++ b/src/lib/terminal.cpp
@@ -7,9 +7,8 @@
 #include "lib/string.h"
 #include "lib/terminal.h"
 
+#include <shellapi.h>
 #include <shlobj.h>
-
-extern BOOL g_cliOptionPortableMode;                     // whether cmd line option /portable is set
 
 extern "C" IMAGE_DOS_HEADER          __ImageBase;        // this DLL's module handle
 #define HMODULE_EXPANDER ((HMODULE) &__ImageBase)
@@ -65,8 +64,89 @@ void WINAPI CustomizeTerminal() {
 
 
 /**
- * Whether the terminal operates in portable mode, i.e. it was launched with the command line parameter "/portable".
- * In portable mode the terminal behaves like under Windows XP or ealier. It uses the installation directory for program data
+ * Parse command line arguments and return the flags of all specified and supported options.
+ *
+ * @return DWORD - option flags
+ */
+DWORD WINAPI GetCliOptions() {
+   static DWORD options = 0;                          // bit mask of specified options
+   static BOOL initialized = FALSE;
+
+   if (!initialized) {
+      int argc = 0;
+      LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+      if (!argv) return !error(ERR_WIN32_ERROR + GetLastError(), "CommandLineToArgvW()");
+
+      DWORD _options = 0;
+      for (int i=1; i < argc; i++) {
+         if (StrStartsWith(argv[i], L"/portable")) {  // The terminal activates portable mode for any CLI argument starting
+            _options |= OPTION_PORTABLE_MODE;         // with "/portable", e.g. "/portable-poo" activates portable mode, too.
+            continue;                                 // This test mirrors that unusual behavior.
+         }
+         if (StrCompare(argv[i], L"/rsf:debug-accountnumber")) {
+            _options |= OPTION_DEBUG_ACCOUNT_NUMBER;
+            continue;
+         }
+         if (StrCompare(argv[i], L"/rsf:debug-accountserver")) {
+            _options |= OPTION_DEBUG_ACCOUNT_SERVER;
+            continue;
+         }
+         if (StrCompare(argv[i], L"/rsf:debug-ec")) {
+            _options |= OPTION_DEBUG_EXECUTION_CONTEXT;
+            continue;
+         }
+         if (StrCompare(argv[i], L"/rsf:debug-indicatorlist")) {
+            _options |= OPTION_DEBUG_INDICATOR_LIST;
+            continue;
+         }
+         if (StrCompare(argv[i], L"/rsf:debug-objectcreate")) {
+            _options |= OPTION_DEBUG_OBJECT_CREATE;
+            continue;
+         }
+      }
+      LocalFree(argv);
+
+      if (!initialized) {                             // another thread may have been faster
+         options = _options;
+      }
+      initialized = TRUE;
+   }
+   return options;
+   #pragma EXPANDER_EXPORT
+}
+
+
+/**
+ * Whether a single command line option is set.
+ *
+ * @return DWORD flag - option flag, one of:
+ *                      OPTION_PORTABLE_MODE:           test for option "/portable"
+ *                      OPTION_DEBUG_ACCOUNT_NUMBER:    test for option "/rsf:debug-accountnumber"
+ *                      OPTION_DEBUG_ACCOUNT_SERVER:    test for option "/rsf:debug-accountserver"
+ *                      OPTION_DEBUG_EXECUTION_CONTEXT: test for option "/rsf:debug-ec"
+ *                      OPTION_DEBUG_INDICATOR_LIST:    test for option "/rsf:debug-indicatorlist"
+ *                      OPTION_DEBUG_OBJECT_CREATE:     test for option "/rsf:debug-objectcreate"
+ * @return BOOL
+ */
+BOOL WINAPI IsCliOption(DWORD flag) {
+   switch (flag) {
+      case OPTION_PORTABLE_MODE:
+      case OPTION_DEBUG_ACCOUNT_NUMBER:
+      case OPTION_DEBUG_ACCOUNT_SERVER:
+      case OPTION_DEBUG_EXECUTION_CONTEXT:
+      case OPTION_DEBUG_INDICATOR_LIST:
+      case OPTION_DEBUG_OBJECT_CREATE:
+         return GetCliOptions() & flag;
+   }
+   error(ERR_INVALID_PARAMETER, "unsupported flag: %d", flag);
+   return FALSE;
+   #pragma EXPANDER_EXPORT
+}
+
+
+/**
+ * Whether the terminal operates in portable mode, i.e. whether it was launched with command line option "/portable".
+ * In portable mode the terminal behaves like under Windows XP or earlier. It uses the installation directory for program data
  * and ignores a UAC-aware environment. Terminal builds <= 509 always operate in portable mode.
  *
  * @return BOOL
@@ -75,7 +155,7 @@ BOOL WINAPI IsPortableMode() {
    static int portableMode = -1;
 
    if (portableMode < 0) {
-      portableMode = (GetTerminalBuild() <= 509 || g_cliOptionPortableMode);
+      portableMode = (GetTerminalBuild() <= 509 || GetCliOptions() & OPTION_PORTABLE_MODE);
    }
    return portableMode;
    #pragma EXPANDER_EXPORT


### PR DESCRIPTION
- introduced a new helper `GetCliOptions()` which parses arguments and caches parsed values
- removed global state for debug options and detection of portable mode

@codex review