### PR TITLE
Capture user logoff / system shutdown notifications

### DIFF
--- a/header/dllmain.h
+++ b/header/dllmain.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "expander.h"
 
-BOOL  WINAPI onProcessAttach();
-BOOL  WINAPI onProcessDetach(BOOL isTerminating);
-DWORD WINAPI onExpanderStart(void* lpParam);
+static BOOL WINAPI onProcessAttach();
+static BOOL WINAPI onProcessDetach(BOOL isTerminating);
+
+static DWORD   WINAPI   ExpanderStartThread(void* lpParam);
+static DWORD   WINAPI   SessionMonitorThread(void* lpParam);
+static LRESULT CALLBACK SessionMonitorWndProc(HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);

--- a/header/lib/timer.h
+++ b/header/lib/timer.h
@@ -15,3 +15,5 @@ struct TICK_TIMER_DATA {
 uint WINAPI SetupTickTimer(HWND hWnd, uint millis, DWORD flags = NULL);
 BOOL WINAPI ReleaseTickTimer(uint timerId);
 void WINAPI ReleaseTickTimers();
+
+static void CALLBACK onTickTimerEvent(TICK_TIMER_DATA* ttd, BOOLEAN timerFired);

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -41,25 +41,26 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID reserved) {
  *
  * @return BOOL - success status
  */
-BOOL WINAPI onProcessAttach() {
+static BOOL WINAPI onProcessAttach() {
    InitializeCriticalSection(&g_expanderMutex);
 
-   g_mqlInstances.   reserve(128);              // TODO: replace global state by getters/setters with local state
+   g_mqlInstances.   reserve(128);        // TODO: replace global state by getters/setters with local state
    g_threads.        reserve(512);
    g_threadsPrograms.reserve(512);
    g_tickTimers.     reserve(32);
 
    // launch worker thread for custom initializations
-   HMODULE hModule = NULL;                      // increase ref-count so the DLL can't be unloaded before the thread finishes
+   HMODULE hModule = NULL;                // increase ref-count so the DLL can't be unloaded before the thread finishes
    GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)onProcessAttach, &hModule);
 
-   HANDLE hThread = CreateThread(NULL, 0, onExpanderStart, hModule, 0, NULL);
-   if (!hThread) {
-      error(ERR_WIN32_ERROR + GetLastError(), "CreateThread()");
-      FreeLibrary(hModule);                     // decrease ref-count if thread creation fails
+   HANDLE hThread = CreateThread(NULL, 0, ExpanderStartThread, hModule, 0, NULL);
+   if (hThread) {
+      CloseHandle(hThread);
    }
-   else CloseHandle(hThread);
-
+   else {
+      error(ERR_WIN32_ERROR + GetLastError(), "CreateThread(\"ExpanderStart\")");
+      FreeLibrary(hModule);               // on error decrease ref-count
+   }
    return TRUE;
 }
 
@@ -71,7 +72,7 @@ BOOL WINAPI onProcessAttach() {
  *
  * @return BOOL - success status
  */
-BOOL WINAPI onProcessDetach(BOOL isTerminating) {
+static BOOL WINAPI onProcessDetach(BOOL isTerminating) {
    if (!isTerminating) {
       DeleteCriticalSection(&g_expanderMutex);
       ReleaseTickTimers();
@@ -82,25 +83,120 @@ BOOL WINAPI onProcessDetach(BOOL isTerminating) {
 
 
 /**
- * Executes DLL start tasks in a separate thread (outside of the DLL loader-lock).
- * These are independant tasks not required for a working DLL.
+ * Executes MT4Expander start tasks in a separate thread (outside of the DLL loader-lock).
+ * These are independant tasks not required for the DLL to load.
  *
- * @param  void* lpParam - DLL module handle as passed by CreateThread()
+ * @param  void* lpParam - DLL module handle
  *
- * @return DWORD - error status
+ * @return DWORD - thread exit status
  */
-DWORD WINAPI onExpanderStart(void* lpParam) {
-   HMODULE hModule = (HMODULE)lpParam;
-
+static DWORD WINAPI ExpanderStartThread(void* lpParam) {
    const wchar* dllName = GetExpanderFileNameW();
    BOOL isProduction = StrEndsWithI(dllName, L"rsfMT4Expander.dll");
 
-   if (isProduction) {                                // lock DLL in memory
-      GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_PIN, (LPCTSTR)onExpanderStart, &hModule);
-      CustomizeTerminal();                            // modifies the UI, subclasses MT4 windows etc.
+   if (!isProduction) {                                        // nothing to do, decrease ref-count and terminate the thread
+      FreeLibraryAndExitThread((HMODULE)lpParam, NO_ERROR);    // this never returns
    }
-   else {
-      FreeLibraryAndExitThread(hModule, NO_ERROR);    // nothing to do, decrease ref-count and terminate the thread
-   }
+
+   // production: lock the DLL in memory
+   HMODULE hModule = NULL;
+   GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_PIN, (LPCTSTR)ExpanderStartThread, &hModule);
+
+   // start a background thread to monitor user logoff/system shutdown events
+   HANDLE hThread = CreateThread(NULL, 0, SessionMonitorThread, hModule, 0, NULL);
+   if (hThread) CloseHandle(hThread);
+   else         error(ERR_WIN32_ERROR + GetLastError(), "CreateThread(\"SessionMonitor\")");
+
+   // customize the UI
+   CustomizeTerminal();
    return NO_ERROR;
+}
+
+
+/**
+ * Create a hidden top-level window and run the message loop to capture WM_QUERYENDSESSION/WM_ENDSESSION messages.
+ * This is a workaround for terminal bug https://github.com/rosasurfer/mt4-expander/issues/26#.
+ *
+ * @param  void* lpParam - DLL module handle
+ *
+ * @return DWORD - thread exit status
+ */
+static DWORD WINAPI SessionMonitorThread(void* lpParam) {
+   HINSTANCE hInstance = (HINSTANCE)lpParam;
+
+   // register the window class
+   const char* className = "SessionMonitorClass";
+   WNDCLASSEXA wc = {};
+   wc.cbSize        = sizeof(WNDCLASSEXA);
+   wc.lpfnWndProc   = SessionMonitorWndProc;
+   wc.hInstance     = hInstance;
+   wc.lpszClassName = className;    // no icon, cursor, background - invisible
+   if (!RegisterClassExA(&wc)) {
+      return error(ERR_WIN32_ERROR + GetLastError(), "RegisterClassExA(\"%s\")", className);
+   }
+
+   // create a message-only window
+   HWND hWnd = CreateWindowExA(
+      0,                            // no extended styles
+      className,
+      "MT4Expander session monitor",
+      0,                            // no style needed
+      0, 0, 0, 0,                   // position/size irrelevant
+      NULL,                         // no parent => top-level window
+      NULL,                         // no menu
+      hInstance,
+      NULL                          // no creation param
+   );
+   if (!hWnd) {
+      UnregisterClassA(className, hInstance);
+      return error(ERR_WIN32_ERROR + GetLastError(), "CreateWindowExA(\"%s\")", className);
+   }
+
+   // run the message loop
+   MSG msg;
+   while (GetMessage(&msg, NULL, 0, 0) > 0) {
+      TranslateMessage(&msg);
+      DispatchMessage(&msg);
+   }
+
+   // clean-up
+   DestroyWindow(hWnd);
+   UnregisterClassA(className, hInstance);
+   return NO_ERROR;
+}
+
+
+/**
+ * SessionMonitor window procedure - runs on the SessionMonitor thread.
+ *
+ * @param  HWND   hWnd   - window receiving the message
+ * @param  uint   msg    - sent message
+ * @param  WPARAM wParam - additional message info
+ * @param  LPARAM lParam - additional message info
+ *
+ * @return LRESULT - depends on the message sent
+ */
+static LRESULT CALLBACK SessionMonitorWndProc(HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam) {
+   switch (msg) {
+      case WM_QUERYENDSESSION: {                   // Windows: "Are you ready to shut down?"
+         if (lParam & ENDSESSION_LOGOFF) {}        // user logoff
+         else                            {}        // system shutdown/restart
+         debug("WM_QUERYENDSESSION  %s", lParam & ENDSESSION_LOGOFF ? "logoff" : "shutdown");
+         return TRUE;                              // we are ready
+      }
+
+      case WM_ENDSESSION: {
+         if (wParam) {                             // Windows: "Logoff/shutdown is happening now. You have ~5 seconds."
+            if (lParam & ENDSESSION_LOGOFF) {}     // user logoff
+            else                            {}     // system shutdown/restart
+            debug("WM_ENDSESSION  %s", lParam & ENDSESSION_LOGOFF ? "logoff" : "shutdown");
+            // do something...
+         }
+         else /*!wParam*/ {}                       // logoff/shutdown was cancelled
+         return 0;
+      }
+
+      default:
+         return DefWindowProc(hWnd, msg, wParam, lParam);
+   }
 }

--- a/src/lib/terminal.cpp
+++ b/src/lib/terminal.cpp
@@ -15,7 +15,7 @@ extern "C" IMAGE_DOS_HEADER          __ImageBase;        // this DLL's module ha
 
 
 /**
- * Customize the terminal's UI.
+ * Customize the terminal UI.
  */
 void WINAPI CustomizeTerminal() {
    // get the terminal main window

--- a/src/lib/timer.cpp
+++ b/src/lib/timer.cpp
@@ -10,12 +10,62 @@ std::vector<TICK_TIMER_DATA*> g_tickTimers;              // all registered tickt
 
 
 /**
+ * Register a timer to send virtual price ticks to the specified chart window.
+ *
+ * @param  HWND  hWnd   - handle of the window to receive virtual ticks
+ * @param  uint  millis - time interval of the virtual ticks in milliseconds
+ * @param  DWORD flags  - tick configuration flags (default: standard ticks for experts and indicators)
+ *                        TICK_CHART_REFRESH:     send command ID_CHART_REFRESH instead of standard ticks (for synthetic and
+ *                                                offline charts)
+ *                        TICK_TESTER:            send command ID_CHART_STEPFORWARD instead of standard ticks (for tester)
+ *                        TICK_IF_WINDOW_VISIBLE: send ticks only if the receiving window is visible (saving of resources)
+ *                        TICK_PAUSE_ON_WEEKEND:  skip sending ticks during sessionbreaks (saving of resources, not yet implemented)
+ *
+ * @return uint - identifier of the registered timer or 0 (NULL) in case of errors
+ */
+uint WINAPI SetupTickTimer(HWND hWnd, uint millis, DWORD flags/*=NULL*/) {
+   // validate parameters
+   DWORD processId = NULL;
+   DWORD threadId = GetWindowThreadProcessId(hWnd, &processId);
+   if (!threadId)                                         return !error(ERR_INVALID_PARAMETER, "invalid parameter hWnd=%p (not a window)", hWnd);
+   if (processId != GetCurrentProcessId())                return !error(ERR_INVALID_PARAMETER, "window hWnd=%p is not owned by the current process", hWnd);
+   if ((int)millis <= 0)                                  return !error(ERR_INVALID_PARAMETER, "invalid parameter millis: %d", (int)millis);
+   if (flags & TICK_CHART_REFRESH && flags & TICK_TESTER) return !error(ERR_INVALID_PARAMETER, "invalid combination in parameter flags: TICK_CHART_REFRESH & TICK_TESTER");
+   if (flags & TICK_PAUSE_ON_WEEKEND)                     warn(ERR_NOT_IMPLEMENTED, "flag TICK_PAUSE_ON_WEEKEND not yet implemented");
+
+   // generate a new timer id and timer metadata
+   if (!TryEnterCriticalSection(&g_expanderMutex)) {
+      debug("waiting for lock on g_expanderMutex...");
+      EnterCriticalSection(&g_expanderMutex);
+   }
+   static uint lastTimerId = 0;                                // a simple counter
+   uint timerId = ++lastTimerId;
+
+   TICK_TIMER_DATA* ttd = new TICK_TIMER_DATA();
+   ttd->timerId  = timerId;
+   ttd->hTimer   = NULL;
+   ttd->interval = millis;
+   ttd->hWnd     = hWnd;
+   ttd->flags    = flags;
+   g_tickTimers.push_back(ttd);                                // may re-allocate, thus needs to be synchronized
+   LeaveCriticalSection(&g_expanderMutex);
+
+   // create the timer
+   if (!CreateTimerQueueTimer(&ttd->hTimer, NULL, (WAITORTIMERCALLBACK) onTickTimerEvent, (void*)ttd, millis, millis, WT_EXECUTEINTIMERTHREAD)) {
+      return !error(ERR_WIN32_ERROR+GetLastError(), "->CreateTimerQueueTimer(interval=%d)", millis);
+   }
+   return ttd->timerId;
+   #pragma EXPANDER_EXPORT
+}
+
+
+/**
  * Callback function for tick timer events.
  *
  * @param  TICK_TIMER_DATA* ttd        - tick timer configuration as passed to CreateTimerQueueTimer()
  * @param  BOOLEAN          timerFired - always TRUE for queued timer callbacks
  */
-VOID CALLBACK onTickTimerEvent(TICK_TIMER_DATA* ttd, BOOLEAN timerFired) {
+static void CALLBACK onTickTimerEvent(TICK_TIMER_DATA* ttd, BOOLEAN timerFired) {
    if (!ttd->hTimer) return;                             // skip queued events of an already released timer
 
    if (IsWindow(ttd->hWnd)) {
@@ -37,56 +87,6 @@ VOID CALLBACK onTickTimerEvent(TICK_TIMER_DATA* ttd, BOOLEAN timerFired) {
 
 
 /**
- * Register a timer to send virtual price ticks to the specified chart window.
- *
- * @param  HWND  hWnd   - handle of the window to receive virtual ticks
- * @param  uint  millis - time interval of the virtual ticks in millicesonds
- * @param  DWORD flags  - tick configuration flags (default: standard ticks for experts and indicators)
- *                        TICK_CHART_REFRESH:     send command ID_CHART_REFRESH instead of standard ticks (for synthetic and
- *                                                offline charts)
- *                        TICK_TESTER:            send command ID_CHART_STEPFORWARD instead of standard ticks (for tester)
- *                        TICK_IF_WINDOW_VISIBLE: send ticks only if the receiving window is visible (saving of resources)
- *                        TICK_PAUSE_ON_WEEKEND:  skip sending ticks during sessionbreaks (saving of resources, not yet implemented)
- *
- * @return uint - identifier of the registered timer or 0 (NULL) in case of errors
- */
-uint WINAPI SetupTickTimer(HWND hWnd, uint millis, DWORD flags/*=NULL*/) {
-   // validate parameters
-   DWORD processId = NULL;
-   DWORD threadId = GetWindowThreadProcessId(hWnd, &processId);
-   if (!threadId)                                         return(!error(ERR_INVALID_PARAMETER, "invalid parameter hWnd=%p (not a window)", hWnd));
-   if (processId != GetCurrentProcessId())                return(!error(ERR_INVALID_PARAMETER, "window hWnd=%p is not owned by the current process", hWnd));
-   if ((int)millis <= 0)                                  return(!error(ERR_INVALID_PARAMETER, "invalid parameter millis: %d", (int)millis));
-   if (flags & TICK_CHART_REFRESH && flags & TICK_TESTER) return(!error(ERR_INVALID_PARAMETER, "invalid combination in parameter flags: TICK_CHART_REFRESH & TICK_TESTER"));
-   if (flags & TICK_PAUSE_ON_WEEKEND)                     warn(ERR_NOT_IMPLEMENTED, "flag TICK_PAUSE_ON_WEEKEND not yet implemented");
-
-   // generate a new timer id and timer metadata
-   if (!TryEnterCriticalSection(&g_expanderMutex)) {
-      debug("waiting for lock on g_expanderMutex...");
-      EnterCriticalSection(&g_expanderMutex);
-   }
-   static uint lastTimerId = 0;                                // a simple counter
-   uint timerId = ++lastTimerId;
-
-   TICK_TIMER_DATA* ttd = new TICK_TIMER_DATA();
-   ttd->timerId  = timerId;
-   ttd->hTimer   = NULL;
-   ttd->interval = millis;
-   ttd->hWnd     = hWnd;
-   ttd->flags    = flags;
-   g_tickTimers.push_back(ttd);                                // may re-allocate, thus needs to be synchronized
-   LeaveCriticalSection(&g_expanderMutex);
-
-   // create the timer
-   if (!CreateTimerQueueTimer(&ttd->hTimer, NULL, (WAITORTIMERCALLBACK)onTickTimerEvent, (void*)ttd, millis, millis, WT_EXECUTEINTIMERTHREAD)) {
-      return(!error(ERR_WIN32_ERROR+GetLastError(), "->CreateTimerQueueTimer(interval=%d)", millis));
-   }
-   return(ttd->timerId);
-   #pragma EXPANDER_EXPORT
-}
-
-
-/**
  * Release a single tick timer.
  *
  * @param  uint timerId - timer id as returned by SetupTickTimer()
@@ -94,7 +94,7 @@ uint WINAPI SetupTickTimer(HWND hWnd, uint millis, DWORD flags/*=NULL*/) {
  * @return BOOL - success status
  */
 BOOL WINAPI ReleaseTickTimer(uint timerId) {
-   if ((int)timerId <= 0) return(!error(ERR_INVALID_PARAMETER, "invalid parameter timerId: %d", timerId));
+   if ((int)timerId <= 0) return !error(ERR_INVALID_PARAMETER, "invalid parameter timerId: %d", timerId);
 
    // The timer is released and marked as invalid. The vector holding all timer entries is not modified.
    uint size = g_tickTimers.size();
@@ -112,10 +112,10 @@ BOOL WINAPI ReleaseTickTimer(uint timerId) {
             }
          }
          else warn(ERR_ILLEGAL_STATE, "tick timer has already been released: id=%d", timerId);
-         return(TRUE);
+         return TRUE;
       }
    }
-   return(!warn(ERR_ILLEGAL_STATE, "tick timer not found: id=%d", timerId));
+   return !warn(ERR_ILLEGAL_STATE, "tick timer not found: id=%d", timerId);
    #pragma EXPANDER_EXPORT
 }
 


### PR DESCRIPTION
see issue #26

On user logoff or system shutdown/restart the terminal doesn't execute MQL `deinit()` / `OnDeinit()` functions. This PR adds a feature to capture `WM_QUERYENDSESSION` / `WM_ENDSESSION` messages from the OS before logoff/shutdown.

@codex review