### PR TITLE
Fix hook execution in SubclassMainWindow()

### DIFF
--- a/header/dllmain.h
+++ b/header/dllmain.h
@@ -1,9 +1,10 @@
 #pragma once
 #include "expander.h"
 
-static BOOL WINAPI onProcessAttach();
-static BOOL WINAPI onProcessDetach(BOOL isTerminating);
-
+static BOOL    WINAPI   onProcessAttach();
+static BOOL    WINAPI   onProcessDetach(BOOL isTerminating);
 static DWORD   WINAPI   ExpanderStartThread(void* lpParam);
 static DWORD   WINAPI   SessionMonitorThread(void* lpParam);
 static LRESULT CALLBACK SessionMonitorWndProc(HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);
+
+BOOL WINAPI PinDllToMemory();

--- a/header/expander.h
+++ b/header/expander.h
@@ -2,14 +2,15 @@
 
 #pragma warning(push)
 
-#pragma warning(error: 4005)                                // promote warning "macro redefinition" to an error
-#pragma warning(disable:4127)                               // conditional expression is constant
-#pragma warning(disable:4706)                               // assignment within conditional expression
+#pragma warning(error:  4005)                               // promote warning "macro redefinition" to an error
 
 #pragma warning(disable:4100)                               // unreferenced formal parameter
 #pragma warning(disable:4101)                               // unreferenced local variable
+#pragma warning(disable:4127)                               // conditional expression is constant
 #pragma warning(disable:4189)                               // local variable is initialized but not referenced
 #pragma warning(disable:4505)                               // unreferenced local function has been removed
+#pragma warning(disable:4702)                               // unreachable code
+#pragma warning(disable:4706)                               // assignment within conditional expression
 #pragma warning(disable:4996)                               // deprecation warnings and function calls with parameters that may be unsafe
 
 #define EXPANDER_EXPORT          comment(linker, "/EXPORT:"__FUNCTION__"="__FUNCDNAME__)

--- a/header/lib/terminal.h
+++ b/header/lib/terminal.h
@@ -4,7 +4,7 @@
 void           WINAPI   CustomizeTerminal();
 static BOOL    WINAPI   SubclassMainWindow(HWND hWndMain, BOOL onUiThread);
 static LRESULT CALLBACK MainWindowSubclassProc(HWND hWnd, uint msg, WPARAM wParam,LPARAM lParam, UINT_PTR subclassId, DWORD_PTR data);
-static LRESULT CALLBACK UiThreadHookProc(int code, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK UiHookProc(int code, WPARAM wParam, LPARAM lParam);
 
 char*        WINAPI FindHistoryDirectoryA(const char* filename, BOOL removeFile);
 HWND         WINAPI FindInputDialogA(ProgramType programType, const char* programName);

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -53,8 +53,7 @@ static BOOL WINAPI onProcessAttach() {
    HMODULE hModule = NULL;                // increase ref-count so the DLL can't be unloaded before the thread finishes
    GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)onProcessAttach, &hModule);
 
-   HANDLE hThread = CreateThread(NULL, 0, ExpanderStartThread, hModule, 0, NULL);
-   if (hThread) {
+   if (HANDLE hThread = CreateThread(NULL, 0, ExpanderStartThread, hModule, 0, NULL)) {
       CloseHandle(hThread);
    }
    else {
@@ -84,30 +83,28 @@ static BOOL WINAPI onProcessDetach(BOOL isTerminating) {
 
 /**
  * Executes MT4Expander start tasks in a separate thread (outside of the DLL loader-lock).
- * These are independant tasks not required for the DLL to load.
+ * These are independant tasks not required for the DLL to work.
  *
  * @param  void* lpParam - DLL module handle
  *
  * @return DWORD - thread exit status
  */
 static DWORD WINAPI ExpanderStartThread(void* lpParam) {
+   HMODULE hModule = (HMODULE)lpParam;
+
    const wchar* dllName = GetExpanderFileNameW();
    BOOL isProduction = StrEndsWithI(dllName, L"rsfMT4Expander.dll");
 
-   if (!isProduction) {                                        // nothing to do, decrease ref-count and terminate the thread
-      FreeLibraryAndExitThread((HMODULE)lpParam, NO_ERROR);    // this never returns
+   if (!isProduction) {                               // nothing to do, decrease ref-count and terminate the thread
+      FreeLibraryAndExitThread(hModule, NO_ERROR);    // this never returns
    }
-
-   // production: lock the DLL in memory
-   HMODULE hModule = NULL;
-   GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_PIN, (LPCTSTR)ExpanderStartThread, &hModule);
+   PinDllToMemory();
 
    // start a background thread to monitor user logoff/system shutdown events
    HANDLE hThread = CreateThread(NULL, 0, SessionMonitorThread, hModule, 0, NULL);
    if (hThread) CloseHandle(hThread);
    else         error(ERR_WIN32_ERROR + GetLastError(), "CreateThread(\"SessionMonitor\")");
 
-   // customize the UI
    CustomizeTerminal();
    return NO_ERROR;
 }
@@ -199,4 +196,21 @@ static LRESULT CALLBACK SessionMonitorWndProc(HWND hWnd, uint msg, WPARAM wParam
       default:
          return DefWindowProc(hWnd, msg, wParam, lParam);
    }
+}
+
+
+/**
+ * Pin the DLL to memory until the process terminates, so it can't be unloaded by calling FreeLibrary().
+ *
+ * @return BOOL - success status
+ */
+BOOL WINAPI PinDllToMemory() {
+   HMODULE hModule = NULL;
+
+   static BOOL pinned = GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_PIN, (LPCTSTR)PinDllToMemory, &hModule);
+   if (!pinned) {
+      static BOOL warned = (BOOL)warn(ERR_WIN32_ERROR + GetLastError(), "GetModuleHandleExA()");
+   }
+   return pinned;
+   #pragma EXPANDER_EXPORT
 }

--- a/src/lib/terminal.cpp
+++ b/src/lib/terminal.cpp
@@ -1,4 +1,5 @@
 #include "expander.h"
+#include "dllmain.h"
 #include "lib/conversion.h"
 #include "lib/datetime.h"
 #include "lib/file.h"
@@ -11,22 +12,19 @@
 #include <shellapi.h>
 #include <shlobj.h>
 
-extern "C" IMAGE_DOS_HEADER          __ImageBase;  // this DLL's module handle
+extern "C" IMAGE_DOS_HEADER          __ImageBase;     // this DLL's module handle
 #define HMODULE_EXPANDER ((HMODULE) &__ImageBase)
 
-static HHOOK g_hUiThreadHook = NULL;               // hook handle to subclass the terminal main window from a non-UI thread
-static const uint g_subclassId = 1;                // main window subclass identifier
+static HHOOK g_hUiHook = NULL;                        // hook handle to subclass the terminal main window from a non-UI thread
+static const uint g_subclassId = 1;                   // main window subclass identifier
 
 
 /**
  * Customize the terminal UI.
  */
 void WINAPI CustomizeTerminal() {
-   // get the terminal main window
    HWND hWndMain = GetTerminalMainWindow();
    if (!hWndMain) return;
-
-   // whether we run in the UI thread
    BOOL isUiThread = IsUIThread();
 
    // subclass the terminal main window
@@ -43,11 +41,11 @@ void WINAPI CustomizeTerminal() {
    struct local {
       static void CloseWindow(HWND hCtrl, BOOL isUiThread) {
          if (isUiThread) {
-            DestroyWindow(hCtrl);                        // can only be called from the UI thread
+            DestroyWindow(hCtrl);                     // must be called from the UI thread
          }
          else {
             PostMessageA(hCtrl, WM_CLOSE, 0, 0);
-            while (IsWindow(hCtrl)) Sleep(100);          // TODO: so ugly, move it to the UI thread
+            while (IsWindow(hCtrl)) Sleep(100);       // TODO: so ugly, move to the UI thread
          }
       }
    };
@@ -76,18 +74,18 @@ void WINAPI CustomizeTerminal() {
  * @return BOOL - success status
  */
 static BOOL WINAPI SubclassMainWindow(HWND hWndMain, BOOL isUiThread) {
-   DWORD_PTR data = 0;  // guard against multiple calls
+   DWORD_PTR data = 0;        // guard against multiple calls
    if (GetWindowSubclass(hWndMain, MainWindowSubclassProc, g_subclassId, &data)) {
       return TRUE;
    }
-   if (isUiThread) {    // on the UI thread we can call SetWindowSubclass() directly
+   if (isUiThread) {          // on the UI thread we can call SetWindowSubclass() directly
       if (!SetWindowSubclass(hWndMain, MainWindowSubclassProc, g_subclassId, 0)) {
          return !error(ERR_WIN32_ERROR + GetLastError(), "SetWindowSubclass()");
       }
    }
-   else {               // otherwise we must install a hook to be executed by the UI thread
-      g_hUiThreadHook = SetWindowsHookEx(WH_CALLWNDPROC, UiThreadHookProc, NULL, GetUIThreadId());
-      if (!g_hUiThreadHook) return !error(ERR_WIN32_ERROR + GetLastError(), "SetWindowsHookEx()");
+   else {                     // otherwise we must install a hook to be executed by the UI thread
+      g_hUiHook = SetWindowsHookEx(WH_CALLWNDPROC, UiHookProc, NULL, GetUIThreadId());
+      if (!g_hUiHook) return !error(ERR_WIN32_ERROR + GetLastError(), "SetWindowsHookEx()");
 
       // wake-up the UI thread with a non-blocking SendMessage()
       SetLastError(ERROR_SUCCESS);
@@ -100,32 +98,6 @@ static BOOL WINAPI SubclassMainWindow(HWND hWndMain, BOOL isUiThread) {
 
 
 /**
- * Callback function registered by SetWindowsHookEx(). Runs in the UI thread.
- *
- * @param  int    code   - whether the hook procedure must process the message
- * @param  WPARAM wParam - whether the message was sent by the current thread
- * @param  LPARAM lParam - pointer to message details
- *
- * @return LRESULT - return value of CallNextHookEx()
- */
-static LRESULT CALLBACK UiThreadHookProc(int code, WPARAM wParam, LPARAM lParam) {
-   if (code >= 0) {
-      if (g_hUiThreadHook) {
-         HHOOK hhk = g_hUiThreadHook;
-         g_hUiThreadHook = NULL;
-         if (!UnhookWindowsHookEx(hhk)) {
-            error(ERR_WIN32_ERROR + GetLastError(), "UnhookWindowsHookEx(hhk=0x%p)", hhk);
-         }
-      }
-      if (!SetWindowSubclass(GetTerminalMainWindow(), MainWindowSubclassProc, g_subclassId, 0)) {
-         error(ERR_WIN32_ERROR + GetLastError(), "SetWindowSubclass()");
-      }
-   }
-   return CallNextHookEx(NULL, code, wParam, lParam);
-}
-
-
-/**
  * The main window's subclassing window procedure. Executed in the UI thread.
  *
  * @param  HWND      hWnd       - subclassed window receiving the message
@@ -133,7 +105,7 @@ static LRESULT CALLBACK UiThreadHookProc(int code, WPARAM wParam, LPARAM lParam)
  * @param  WPARAM    wParam     - additional message info
  * @param  LPARAM    lParam     - additional message info
  * @param  UINT_PTR  subclassId - subclass identifier
- * @param  DWORD_PTR data       - custom user data passed to SetWindowSubclass()
+ * @param  DWORD_PTR data       - user data as passed to SetWindowSubclass()
  *
  * @return LRESULT - depends on the message sent
  */
@@ -150,6 +122,32 @@ static LRESULT CALLBACK MainWindowSubclassProc(HWND hWnd, uint msg, WPARAM wPara
       }
    }
    return DefSubclassProc(hWnd, msg, wParam, lParam);
+}
+
+
+/**
+ * Callback function registered by SetWindowsHookEx(). Runs in the UI thread.
+ *
+ * @param  int    code   - whether the hook procedure must process the message
+ * @param  WPARAM wParam - whether the message was sent by the current thread
+ * @param  LPARAM lParam - pointer to message details
+ *
+ * @return LRESULT - return value of CallNextHookEx()
+ */
+static LRESULT CALLBACK UiHookProc(int code, WPARAM wParam, LPARAM lParam) {
+   if (code >= 0) {
+      if (g_hUiHook) {
+         HHOOK hHook = g_hUiHook;
+         g_hUiHook = NULL;
+         if (!UnhookWindowsHookEx(hHook)) {
+            error(ERR_WIN32_ERROR + GetLastError(), "UnhookWindowsHookEx(hHook=0x%p)", hHook);
+         }
+      }
+      if (!SetWindowSubclass(GetTerminalMainWindow(), MainWindowSubclassProc, g_subclassId, 0)) {
+         error(ERR_WIN32_ERROR + GetLastError(), "SetWindowSubclass()");
+      }
+   }
+   return CallNextHookEx(NULL, code, wParam, lParam);
 }
 
 
@@ -1072,14 +1070,14 @@ BOOL WINAPI LoadMqlProgramW(HWND hChart, ProgramType programType, const wchar* p
    }
    if (!IsFileW(file.c_str(), MODE_SYSTEM)) return !error(ERR_FILE_NOT_FOUND, "file not found: \"%S\"", file.c_str());
 
+   // create a copy of programName on the heap (`programName` may be immediately destroyed after return)
+   const wchar* name = wsdup(programName);               // TODO: add to GC
+
    // trigger the launch of the program
-   PostMessageW(hChart, WM_MT4(), cmd, (LPARAM)wsdup(programName));     // pass a copy of programName (the passed value may get immediately destroyed)
-   debug("queued launch of %s \"%S\"", sProgramType, programName);
-
-   // prevent the DLL from getting unloaded before the message is processed
-   HMODULE hModule = NULL;
-   GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_PIN, (LPCWSTR)LoadMqlProgramW, &hModule);
-
+   PinDllToMemory();                                     // prevent the DLL from being unloaded before the message is processed
+   if (PostMessageW(hChart, WM_MT4(), cmd, (LPARAM)name)) {
+      debug("queued launch of %s \"%S\"", sProgramType, name);
+   }
    return TRUE;
    #pragma EXPANDER_EXPORT
 }

--- a/src/lib/terminal.cpp
+++ b/src/lib/terminal.cpp
@@ -29,7 +29,7 @@ void WINAPI CustomizeTerminal() {
    // whether we run in the UI thread
    BOOL isUiThread = IsUIThread();
 
-   // subclass the terminal main window (must be the first customization task)
+   // subclass the terminal main window
    SubclassMainWindow(hWndMain, isUiThread);
 
    // get the toolbar
@@ -88,7 +88,12 @@ static BOOL WINAPI SubclassMainWindow(HWND hWndMain, BOOL isUiThread) {
    else {               // otherwise we must install a hook to be executed by the UI thread
       g_hUiThreadHook = SetWindowsHookEx(WH_CALLWNDPROC, UiThreadHookProc, NULL, GetUIThreadId());
       if (!g_hUiThreadHook) return !error(ERR_WIN32_ERROR + GetLastError(), "SetWindowsHookEx()");
-      PostMessage(hWndMain, WM_NULL, 0, 0);   // wake-up the UI thread (cosmetic)
+
+      // wake-up the UI thread with a non-blocking SendMessage()
+      SetLastError(ERROR_SUCCESS);
+      if (!SendMessageTimeout(hWndMain, WM_NULL, 0, 0, SMTO_NORMAL, 1000, NULL)) {
+         notice(ERR_WIN32_ERROR + GetLastError(), "SendMessageTimeout()");
+      }
    }
    return TRUE;
 }
@@ -128,7 +133,7 @@ static LRESULT CALLBACK UiThreadHookProc(int code, WPARAM wParam, LPARAM lParam)
  * @param  WPARAM    wParam     - additional message info
  * @param  LPARAM    lParam     - additional message info
  * @param  UINT_PTR  subclassId - subclass identifier
- * @param  DWORD_PTR data       - reference data
+ * @param  DWORD_PTR data       - custom user data passed to SetWindowSubclass()
  *
  * @return LRESULT - depends on the message sent
  */


### PR DESCRIPTION
On irrelevant code changes the hook was sometimes executed, sometimes not. In current MT4 builds it was executed, in older builds it was not. Spurious and not reproducable.

- replaced PostMessage() by the more correct SendMessage()

@codex review