### PR TITLE
Fix "MDIClient: chart window for `Symbol,Period` not found" in terminal startup scripts

### DIFF
--- a/header/expander.h
+++ b/header/expander.h
@@ -153,6 +153,7 @@ int __cdecl debug_raw(const char* message, ...);
 int         __cdecl _EMPTY       (...);
 int         __cdecl _EMPTY_VALUE (...);
 const char* __cdecl _EMPTY_STR   (...);
+string      __cdecl _empty_str   (...);
 HWND        __cdecl _INVALID_HWND(...);
 int         __cdecl _NULL        (...);
 bool        __cdecl _true        (...);

--- a/header/lib/helper.h
+++ b/header/lib/helper.h
@@ -3,7 +3,6 @@
 
 BOOL        WINAPI IsDebugBuild();
 
-uint        WINAPI ComposeChartTitle(const char* symbol, uint timeframe, char* buffer, uint bufferSize);
 char*       WINAPI GetInternalWindowTextA(HWND hWnd);
 wchar*      WINAPI GetInternalWindowTextW(HWND hWnd);
 DWORD       WINAPI GetLastWin32Error();
@@ -17,6 +16,7 @@ BOOL        WINAPI IsProgramType(int type);
 BOOL        WINAPI IsUIThread(DWORD threadId = NULL);
 BOOL        WINAPI IsVirtualKeyDown(int key);
 BOOL        WINAPI IsWindowAreaVisible(HWND hWnd);
+char*       WINAPI MakeChartTitleA(const char* symbol, uint timeframe);
 uint        WINAPI MT4InternalMsg();
 uint        WINAPI WM_MT4();
 

--- a/header/lib/helper.h
+++ b/header/lib/helper.h
@@ -16,7 +16,7 @@ BOOL        WINAPI IsProgramType(int type);
 BOOL        WINAPI IsUIThread(DWORD threadId = NULL);
 BOOL        WINAPI IsVirtualKeyDown(int key);
 BOOL        WINAPI IsWindowAreaVisible(HWND hWnd);
-char*       WINAPI MakeChartTitleA(const char* symbol, uint timeframe);
+string      WINAPI makeChartTitle(const char* symbol, uint timeframe);
 uint        WINAPI MT4InternalMsg();
 uint        WINAPI WM_MT4();
 

--- a/header/lib/string.h
+++ b/header/lib/string.h
@@ -98,7 +98,9 @@ BOOL         WINAPI StrEndsWith(const char* str, const char* suffix);
 BOOL         WINAPI StrEndsWith(const wchar* str, const wchar* suffix);
 BOOL         WINAPI StrEndsWithI(const char* str, const char* suffix);
 BOOL         WINAPI StrEndsWithI(const wchar* str, const wchar* suffix);
-string&      WINAPI StrReplace(string &subject, const string &search, const string &replace, size_t count=INT_MAX);
+
+string       WINAPI strLeftTo(const string &subject, const string &limiter, int count = 1);
+string&      WINAPI strReplace(string &subject, const string &search, const string &replace, size_t count = INT_MAX);
 
 char*        WINAPI strToLower(char* str);
 wchar*       WINAPI strToLower(wchar* str);

--- a/header/shared/bak/defines.h
+++ b/header/shared/bak/defines.h
@@ -454,13 +454,15 @@
 
 
 // MT4 control ids (windows, controls, ui elements)
-#define IDC_TOOLBAR                         59419        // Toolbar
+#define IDC_TOOLBAR                         59419        // toolbar
 #define IDC_TOOLBAR_COMMUNITY_BUTTON        38160        // MQL4/MQL5 community button (terminal builds <= 509)
 #define IDC_TOOLBAR_SEARCHBOX               38213        // search box                 (terminal builds > 509)
 #define IDC_STATUSBAR                       59393        // status bar
-#define IDC_MDI_CLIENT                      59648        // main MDI container (holding all charts)
-#define IDC_DOCKED_CONTAINER                59422        // window containing all dockable child windows docked to the main application window
-#define IDC_FLOATING_CONTAINER              59423        // window containing a single dockable but floating child window (possibly more than one, not a toplevel window)
+#define IDC_DOCKED_CONTAINER                59422        // window containing all dockable child windows docked to the main terminal window
+#define IDC_FLOATING_CONTAINER              59423        // window containing a single dockable but floating child window (possibly more than one, not a top-level window)
+#define IDC_MDICLIENT                       59648        // MDI container window (holding all chart windows)
+#define IDC_MDICLIENT_CHART1                65280        // first chart window
+#define IDC_MDICLIENT_CHART_FRAME   IDC_MDICLIENT        // a chart window's painting area (AfxFrameOrView), return value of MQL::WindowHandle()
 
 #define IDC_CUSTOM_INDICATOR_OK                 1        // load dialog "Custom Indicator"
 #define IDC_CUSTOM_INDICATOR_CANCEL             2        // ...

--- a/src/expander.cpp
+++ b/src/expander.cpp
@@ -67,8 +67,7 @@ int __cdecl _dump(const char* fileName, const char* funcName, uint line, const v
  */
 int __cdecl debug_raw(const char* message, ...) {
    const char* msg = message;
-   if (!msg)  msg = "(null)";
-   if (!*msg) msg = "(empty)";
+   if (!msg) msg = "(null)";
 
    // format the variable parameters
    va_list args;
@@ -100,8 +99,7 @@ int __cdecl debug_raw(const char* message, ...) {
  */
 int __cdecl _debug(const char* fileName, const char* funcName, uint line, const char* message, ...) {
    const char* msg = message;
-   if (!msg)  msg = "(null)";
-   if (!*msg) msg = "(empty)";
+   if (!msg) msg = "(null)";
 
    // format the variable parameters
    va_list args;
@@ -137,8 +135,7 @@ int __cdecl _debug(const char* fileName, const char* funcName, uint line, const 
  */
 int __cdecl _debug(const char* fileName, const char* funcName, uint line, int error, const char* message, ...) {
    const char* msg = message;
-   if (!msg)  msg = "(null)";
-   if (!*msg) msg = "(empty)";
+   if (!msg) msg = "(null)";
 
    // format the variable parameters
    va_list args;
@@ -180,8 +177,7 @@ int __cdecl _debug(const char* fileName, const char* funcName, uint line, int er
  */
 int __cdecl _info(const char* fileName, const char* funcName, uint line, const char* message, ...) {
    const char* msg = message;
-   if (!msg)  msg = "(null)";
-   if (!*msg) msg = "(empty)";
+   if (!msg) msg = "(null)";
 
    // format the variable parameters
    va_list args;
@@ -217,8 +213,7 @@ int __cdecl _info(const char* fileName, const char* funcName, uint line, const c
  */
 int __cdecl _info(const char* fileName, const char* funcName, uint line, int error, const char* message, ...) {
    const char* msg = message;
-   if (!msg)  msg = "(null)";
-   if (!*msg) msg = "(empty)";
+   if (!msg) msg = "(null)";
 
    // format the variable parameters
    va_list args;
@@ -260,8 +255,7 @@ int __cdecl _info(const char* fileName, const char* funcName, uint line, int err
  */
 int __cdecl _notice(const char* fileName, const char* funcName, uint line, const char* message, ...) {
    const char* msg = message;
-   if (!msg)  msg = "(null)";
-   if (!*msg) msg = "(empty)";
+   if (!msg) msg = "(null)";
 
    // format the variable parameters
    va_list args;
@@ -297,8 +291,7 @@ int __cdecl _notice(const char* fileName, const char* funcName, uint line, const
  */
 int __cdecl _notice(const char* fileName, const char* funcName, uint line, int error, const char* message, ...) {
    const char* msg = message;
-   if (!msg)  msg = "(null)";
-   if (!*msg) msg = "(empty)";
+   if (!msg) msg = "(null)";
 
    // format the variable parameters
    va_list args;
@@ -340,8 +333,7 @@ int __cdecl _notice(const char* fileName, const char* funcName, uint line, int e
  */
 int __cdecl _warn(const char* fileName, const char* funcName, uint line, const char* message, ...) {
    const char* msg = message;
-   if (!msg)  msg = "(null)";
-   if (!*msg) msg = "(empty)";
+   if (!msg) msg = "(null)";
 
    // format the variable parameters
    va_list args;
@@ -391,8 +383,7 @@ int __cdecl _warn(const char* fileName, const char* funcName, uint line, const c
  */
 int __cdecl _warn(const char* fileName, const char* funcName, uint line, int error, const char* message, ...) {
    const char* msg = message;
-   if (!msg)  msg = "(null)";
-   if (!*msg) msg = "(empty)";
+   if (!msg) msg = "(null)";
 
    // format the variable parameters
    va_list args;
@@ -448,11 +439,10 @@ int __cdecl _warn(const char* fileName, const char* funcName, uint line, int err
  * @return int - the passed error code
  */
 int __cdecl _error(const char* fileName, const char* funcName, uint line, int error, const char* message, ...) {
-   if (!error) return 0;
+   if (!error) return NO_ERROR;
 
    const char* msg = message;
-   if (!msg)  message = "(null)";
-   if (!*msg) message = "(empty)";
+   if (!msg) message = "(null)";
 
    // format the variable parameters
    va_list args;
@@ -492,6 +482,7 @@ int __cdecl _error(const char* fileName, const char* funcName, uint line, int er
 int         __cdecl _EMPTY       (...) { return EMPTY;        }      // only __cdecl supports variadics
 int         __cdecl _EMPTY_VALUE (...) { return EMPTY_VALUE;  }
 const char* __cdecl _EMPTY_STR   (...) { return "";           }
+string      __cdecl _empty_str   (...) { return string();     }
 HWND        __cdecl _INVALID_HWND(...) { return INVALID_HWND; }
 int         __cdecl _NULL        (...) { return NULL;         }
 bool        __cdecl _true        (...) { return true;         }

--- a/src/lib/conversion.cpp
+++ b/src/lib/conversion.cpp
@@ -1966,37 +1966,37 @@ const char* WINAPI OrderTypeToStr(int type) {
  *
  * @param  int period - timeframe identifier or amount of minutes per bar period
  *
- * @return char* - description or a NULL pointer if the parameter is invalid
+ * @return char* - description or a NULL pointer in case of errors
  *
  * Note: This implementation should match the one in MQL's stdfunctions.mqh.
  */
 const char* WINAPI PeriodDescriptionA(int period) {
-   if (period < 0) return((char*)!error(ERR_INVALID_PARAMETER, "invalid parameter period: %d", period));
+   if (period < 0) return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter period: %d", period);
 
    switch (period) {
-      case NULL      : return("(null)");
-      case PERIOD_M1 : return("M1");      // 1 minute
-      case PERIOD_M2 : return("M2");      // 2 minutes  (custom timeframe)
-      case PERIOD_M3 : return("M3");      // 3 minutes  (custom timeframe)
-      case PERIOD_M4 : return("M4");      // 4 minutes  (custom timeframe)
-      case PERIOD_M5 : return("M5");      // 5 minutes
-      case PERIOD_M6 : return("M6");      // 6 minutes  (custom timeframe)
-      case PERIOD_M10: return("M10");     // 10 minutes (custom timeframe)
-      case PERIOD_M12: return("M12");     // 12 minutes (custom timeframe)
-      case PERIOD_M15: return("M15");     // 15 minutes
-      case PERIOD_M20: return("M20");     // 20 minutes (custom timeframe)
-      case PERIOD_M30: return("M30");     // 30 minutes
-      case PERIOD_H1 : return("H1");      // 1 hour
-      case PERIOD_H2 : return("H2");      // 2 hours    (custom timeframe)
-      case PERIOD_H3 : return("H3");      // 3 hours    (custom timeframe)
-      case PERIOD_H4 : return("H4");      // 4 hours
-      case PERIOD_H6 : return("H6");      // 6 hours    (custom timeframe)
-      case PERIOD_H8 : return("H8");      // 8 hours    (custom timeframe)
-      case PERIOD_H12: return("H12");     // 12 hours   (custom timeframe)
-      case PERIOD_D1 : return("D1");      // 1 day
-      case PERIOD_W1 : return("W1");      // 1 week
-      case PERIOD_MN1: return("MN1");     // 1 month
-      case PERIOD_Q1 : return("Q1");      // 1 quarter  (custom timeframe)
+      case NULL      : return "(null)";
+      case PERIOD_M1 : return "M1";       // 1 minute
+      case PERIOD_M2 : return "M2";       // 2 minutes  (custom timeframe)
+      case PERIOD_M3 : return "M3";       // 3 minutes  (custom timeframe)
+      case PERIOD_M4 : return "M4";       // 4 minutes  (custom timeframe)
+      case PERIOD_M5 : return "M5";       // 5 minutes
+      case PERIOD_M6 : return "M6";       // 6 minutes  (custom timeframe)
+      case PERIOD_M10: return "M10";      // 10 minutes (custom timeframe)
+      case PERIOD_M12: return "M12";      // 12 minutes (custom timeframe)
+      case PERIOD_M15: return "M15";      // 15 minutes
+      case PERIOD_M20: return "M20";      // 20 minutes (custom timeframe)
+      case PERIOD_M30: return "M30";      // 30 minutes
+      case PERIOD_H1 : return "H1";       // 1 hour
+      case PERIOD_H2 : return "H2";       // 2 hours    (custom timeframe)
+      case PERIOD_H3 : return "H3";       // 3 hours    (custom timeframe)
+      case PERIOD_H4 : return "H4";       // 4 hours
+      case PERIOD_H6 : return "H6";       // 6 hours    (custom timeframe)
+      case PERIOD_H8 : return "H8";       // 8 hours    (custom timeframe)
+      case PERIOD_H12: return "H12";      // 12 hours   (custom timeframe)
+      case PERIOD_D1 : return "D1";       // 1 day
+      case PERIOD_W1 : return "W1";       // 1 week
+      case PERIOD_MN1: return "MN1";      // 1 month
+      case PERIOD_Q1 : return "Q1";       // 1 quarter  (custom timeframe)
    }
    return asformat("%d", period);         // TODO: mixed memory location (add to GC)
 }
@@ -2024,32 +2024,32 @@ wchar* WINAPI PeriodDescriptionW(int period) {
  * @return char* - string or NULL if the parameter is invalid
  */
 const char* WINAPI PeriodToStr(int period) {
-   if (period < 0) return((char*)!error(ERR_INVALID_PARAMETER, "invalid parameter period: %d", period));
+   if (period < 0) return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter period: %d", period);
 
    switch (period) {
-      case NULL      : return("(null)"    );
-      case PERIOD_M1 : return("PERIOD_M1" );     // 1 minute
-      case PERIOD_M2 : return("PERIOD_M2" );     // 2 minutes  (custom timeframe)
-      case PERIOD_M3 : return("PERIOD_M3" );     // 3 minutes  (custom timeframe)
-      case PERIOD_M4 : return("PERIOD_M4" );     // 4 minutes  (custom timeframe)
-      case PERIOD_M5 : return("PERIOD_M5" );     // 5 minutes
-      case PERIOD_M6 : return("PERIOD_M6" );     // 6 minutes  (custom timeframe)
-      case PERIOD_M10: return("PERIOD_M10");     // 10 minutes (custom timeframe)
-      case PERIOD_M12: return("PERIOD_M12");     // 12 minutes (custom timeframe)
-      case PERIOD_M15: return("PERIOD_M15");     // 15 minutes
-      case PERIOD_M20: return("PERIOD_M20");     // 20 minutes (custom timeframe)
-      case PERIOD_M30: return("PERIOD_M30");     // 30 minutes
-      case PERIOD_H1 : return("PERIOD_H1" );     // 1 hour
-      case PERIOD_H2 : return("PERIOD_H2" );     // 2 hours    (custom timeframe)
-      case PERIOD_H3 : return("PERIOD_H3" );     // 3 hours    (custom timeframe)
-      case PERIOD_H4 : return("PERIOD_H4" );     // 4 hours
-      case PERIOD_H6 : return("PERIOD_H6" );     // 6 hours    (custom timeframe)
-      case PERIOD_H8 : return("PERIOD_H8" );     // 8 hours    (custom timeframe)
-      case PERIOD_H12: return("PERIOD_H12");     // 12 hours   (custom timeframe)
-      case PERIOD_D1 : return("PERIOD_D1" );     // 1 day
-      case PERIOD_W1 : return("PERIOD_W1" );     // 1 week
-      case PERIOD_MN1: return("PERIOD_MN1");     // 1 month
-      case PERIOD_Q1 : return("PERIOD_Q1" );     // 1 quarter  (custom timeframe)
+      case NULL      : return "(null)";
+      case PERIOD_M1 : return "PERIOD_M1";       // 1 minute
+      case PERIOD_M2 : return "PERIOD_M2";       // 2 minutes  (custom timeframe)
+      case PERIOD_M3 : return "PERIOD_M3";       // 3 minutes  (custom timeframe)
+      case PERIOD_M4 : return "PERIOD_M4";       // 4 minutes  (custom timeframe)
+      case PERIOD_M5 : return "PERIOD_M5";       // 5 minutes
+      case PERIOD_M6 : return "PERIOD_M6";       // 6 minutes  (custom timeframe)
+      case PERIOD_M10: return "PERIOD_M10";      // 10 minutes (custom timeframe)
+      case PERIOD_M12: return "PERIOD_M12";      // 12 minutes (custom timeframe)
+      case PERIOD_M15: return "PERIOD_M15";      // 15 minutes
+      case PERIOD_M20: return "PERIOD_M20";      // 20 minutes (custom timeframe)
+      case PERIOD_M30: return "PERIOD_M30";      // 30 minutes
+      case PERIOD_H1 : return "PERIOD_H1";       // 1 hour
+      case PERIOD_H2 : return "PERIOD_H2";       // 2 hours    (custom timeframe)
+      case PERIOD_H3 : return "PERIOD_H3";       // 3 hours    (custom timeframe)
+      case PERIOD_H4 : return "PERIOD_H4";       // 4 hours
+      case PERIOD_H6 : return "PERIOD_H6";       // 6 hours    (custom timeframe)
+      case PERIOD_H8 : return "PERIOD_H8";       // 8 hours    (custom timeframe)
+      case PERIOD_H12: return "PERIOD_H12";      // 12 hours   (custom timeframe)
+      case PERIOD_D1 : return "PERIOD_D1";       // 1 day
+      case PERIOD_W1 : return "PERIOD_W1";       // 1 week
+      case PERIOD_MN1: return "PERIOD_MN1";      // 1 month
+      case PERIOD_Q1 : return "PERIOD_Q1";       // 1 quarter  (custom timeframe)
    }
    return (char*)!error(ERR_INVALID_PARAMETER, "unknown parameter period: %d", period);
    #pragma EXPANDER_EXPORT

--- a/src/lib/executioncontext.cpp
+++ b/src/lib/executioncontext.cpp
@@ -6,6 +6,7 @@
 #include "lib/math.h"
 #include "lib/string.h"
 #include "lib/terminal.h"
+#include "lib/win32.h"
 #include "struct/ExecutionContext.h"
 
 #include <fstream>
@@ -1116,11 +1117,11 @@ uint WINAPI FindModuleInLimbo(ModuleType moduleType, const char* name, Uninitial
 /**
  * Find the chart of the current program and return its window handle.
  *
- * Called from MqlProgram_init() to resolve an invalid chart handle in terminal builds <= 509, i.e. MQL::WindowHandle() = NULL.
+ * Called from MqlProgram_init() to resolve an unresolved chart handle in terminal builds <= 509, i.e. MQL::WindowHandle() = 0.
  * This function resolves the handle correctly.
  *
- * Since build 600 the terminal delays execution of MQL::init() until the handle is officially known. This delay siginificantly
- * slows down terminal start and chart initialization. Thank you, MetaQuotes.
+ * Since build 600 the terminal delays execution of MQL::init() until the handle is known. This delay siginificantly slows
+ * down terminal start and chart initialization. Thank you, MetaQuotes.
  *
  * @param  char*              programName    - program name (with or w/o path depending on the terminal version)
  * @param  ModuleType         moduleType     - module type
@@ -1131,8 +1132,8 @@ uint WINAPI FindModuleInLimbo(ModuleType moduleType, const char* name, Uninitial
  * @param  BOOL               isVisualMode   - result of IsVisualMode() as returned by the terminal (possibly incorrect, e.g. for scripts or standalone indicators in tester)
  * @param  BOOL               isOptimization - result of IsOptimzation() as returned by the terminal
  *
- * @return HWND - resolved Window handle or NULL if the program runs in the tester with VisualMode=off;
- *                INVALID_HWND (-1) in case of errors
+ * @return HWND - resolved chart window handle or NULL if the program runs in the tester with VisualMode=off;
+ *                or INVALID_HWND (-1) in case of errors
  */
 HWND WINAPI FindWindowHandle(const char* programName, ModuleType moduleType, const EXECUTION_CONTEXT* sec, const char* symbol, uint timeframe, BOOL isTesting, BOOL isVisualMode, BOOL isOptimization) {
    if (sec) return sec->chart;                                    // with a super context return the inherited chart handle
@@ -1154,12 +1155,12 @@ HWND WINAPI FindWindowHandle(const char* programName, ModuleType moduleType, con
    HWND hWndMain = GetTerminalMainWindow();
    if (!hWndMain) return INVALID_HWND;
 
-   HWND hWndMdi  = GetDlgItem(hWndMain, IDC_MDI_CLIENT);
-   if (!hWndMdi) return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MDIClient window not found (hWndMain=%p)", hWndMain));
+   HWND hWndMdi  = GetDlgItem(hWndMain, IDC_MDICLIENT);
+   if (!hWndMdi) return _INVALID_HWND(error(ERR_WIN32_ERROR + GetLastError(), "GetDlgItem(MainWindow, IDC_MDICLIENT)"));
 
    HWND hChartWindow = NULL;                                      // chart system window holding the chart AfxFrameOrView
 
-   // indicator
+   // indicators
    if (moduleType == MT_INDICATOR) {
       // situation:
       //  We are either a regular indicator in an online chart in the UI thread (terminal-start or reload-profile).
@@ -1171,9 +1172,9 @@ HWND WINAPI FindWindowHandle(const char* programName, ModuleType moduleType, con
       // WindowHandle() uses the title string to find a chart window. On execution of indicator::init() the window title may
       // not yet be set which results in the function returning NULL (can't find current window). However the window exists.
       // There's always only one window "in creation" without a title text, and it's always the last created window (the last
-      // child window in Z order). So even without a title text the own window can be detected.
+      // child window in order of control ids). So even without a title text the own window can be detected.
       //
-      // If there's no last window in Z order without a title text, then the indicator was loaded by a tester template with
+      // If there's no last window without a title text, then the indicator was loaded by a tester template with
       // VisualMode=off (no chart window). In this case init() is executed but start() will never.
       //
       HWND hWndChild = GetWindow(hWndMdi, GW_CHILD);              // first child in Z order (first chart)
@@ -1185,53 +1186,67 @@ HWND WINAPI FindWindowHandle(const char* programName, ModuleType moduleType, con
       hChartWindow = hWndLast;                                    // keep last chart (holding the chart AfxFrameOrView)
    }
 
-   // script
+   // scripts
    else if (moduleType == MT_SCRIPT) {
-      // Bis Build 509+ ??? kann WindowHandle() bei Terminalstart oder LoadProfile in init() und in start() 0 zurückgeben,
-      // solange Terminal/Chart nicht endgültig initialisiert sind. Ein laufendes Script wurde in diesem Fall über
-      // die Konfiguration in "terminal-start.ini" gestartet und läuft im ersten passenden Chart in absoluter Reihenfolge
-      // (CtrlID, nicht Z order).
-      HWND hWndChild = GetWindow(hWndMdi, GW_CHILD);              // first child window in Z order (top-most chart window)
-      if (!hWndChild) return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MDIClient window has no children in Script::init()  hWndMain=%p", hWndMain));
+      // MQL scripts run in their own thread. If a script is launched via terminal startup configuration ("start.ini"), it's
+      // possible that the script's chart has not yet been fully initialized by the UI thread, and WindowHandle() in the script
+      // returns 0.
+      //
+      // The chart window always exists but the UI thread initially creates it with an empty title. Then the title is set using
+      // a WM_SETTEXT message. As long as this message hasn't been processed, WindowHandle() in the script thread returns 0.
+      // This can occur particularly in terminals of build <= 509. Starting with build 600, WindowHandle() in scripts doesn't
+      // return 0 anymore.
+      //
+      // If no chart symbol is specified in the startup configuration ("start.ini"), the script runs on the first created
+      // chart. This chart should match the script values of Symbol() and Period(). If a chart symbol is specified in the
+      // startup configuration, the terminal opens a new chart window for the script, and the script runs on the last matching
+      // chart window. Order is determined by control ids (not Z order).
+      //
+      // Workaround: There can only ever be one window whose initialization is incomplete, that's the last created one. Since
+      // a script's chart window always exists, if no other window matches, the window with an empty title must be the script's
+      // chart window.
 
-      char *chartTitle = MakeChartTitleA(symbol, timeframe), *wndTitle = NULL;
-      if (!chartTitle) return INVALID_HWND;
-      int id = INT_MAX;
+      char* wndTitle = NULL;
+      string refTitle = makeChartTitle(symbol, timeframe);
 
-      while (hWndChild) {                                         // iterate over all child windows
+      // iterate over all chart windows in creation order (using Z order can corrupt the result)
+      HWND hWndChild = NULL;
+      int i = 0;
+
+      while (hWndChild = GetDlgItem(hWndMdi, IDC_MDICLIENT_CHART1 + i)) {
          free(wndTitle);
-         wndTitle = GetWindowTextA(hWndChild);                    // Here we can't use GetInternalWindowText() as the window
-         if (!wndTitle) return _INVALID_HWND(bfree(chartTitle));  // creation needs to finish before we get a valid response.
+         wndTitle = GetInternalWindowTextA(hWndChild);
+         if (!wndTitle) return INVALID_HWND;
 
-         if (StrEndsWith(wndTitle, " (offline)")) {
-            wndTitle[strlen(wndTitle)-10] = '\0';
+         if (!*wndTitle) {                   // An empty title may happen only for the last created window.
+            hChartWindow = hWndChild;        // As nothing else matched before, this must be the script's chart window.
+            break;
          }
-         if (StrCompare(wndTitle, chartTitle)) {                  // find all matching windows
-            id = std::min(id, GetDlgCtrlID(hWndChild));           // track the smallest in absolute order
-            if (!id) return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MDIClient child %p has no control id", hWndChild), bfree(chartTitle, wndTitle));
+         string title = strLeftTo(wndTitle, " (offline)", -1);
+         if (title == refTitle) {
+            hChartWindow = hWndChild;        // our chart window
+            break;
          }
-         hWndChild = GetWindow(hWndChild, GW_HWNDNEXT);           // next child in Z order
+         i++;
       }
-      if (id == INT_MAX) {
-         error(ERR_RUNTIME_ERROR, "no matching MDIClient child found for \"%s\"", chartTitle);
-         return _INVALID_HWND(bfree(chartTitle, wndTitle));
-      }
-      free(chartTitle, wndTitle);
+      free(wndTitle);
 
-      hChartWindow = GetDlgItem(hWndMdi, id);                     // keep chart window (holding the chart AfxFrameOrView)
+      if (!hChartWindow) {
+         return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MDIClient: no \"%s\" chart window found", refTitle), EnumChildWindowsToDebug(hWndMdi));
+      }
    }
 
-   // expert
+   // experts
    else if (moduleType == MT_EXPERT) {
-      return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MQL::WindowHandle() => 0"));
+      return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MQL::WindowHandle() = 0"));
    }
    else {
       return _INVALID_HWND(error(ERR_INVALID_PARAMETER, "invalid parameter moduleType: %d", moduleType));
    }
 
-   // The found chart window holds a single child window (AfxFrameOrView), which matches the handle of MQL::WindowHandle().
-   HWND hChart = GetWindow(hChartWindow, GW_CHILD);
-   if (!hChart) return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "last MDIClient child window %p: no chart frame found", hChartWindow));
+   // the painting area of the found chart (AfxFrameOrView) is the wanted return value of MQL::WindowHandle()
+   HWND hChart = GetDlgItem(hChartWindow, IDC_MDICLIENT_CHART_FRAME);
+   if (!hChart) return _INVALID_HWND(error(ERR_WIN32_ERROR + GetLastError(), "GetDlgItem(ChartWindow, IDC_MDICLIENT_CHART_FRAME)"));
 
    return hChart;
 }

--- a/src/lib/executioncontext.cpp
+++ b/src/lib/executioncontext.cpp
@@ -1232,7 +1232,7 @@ HWND WINAPI FindWindowHandle(const char* programName, ModuleType moduleType, con
       free(wndTitle);
 
       if (!hChartWindow) {
-         return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MDIClient: no \"%s\" chart window found", refTitle), EnumChildWindowsToDebug(hWndMdi));
+         return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MDIClient: no \"%s\" chart window found", refTitle.c_str()), EnumChildWindowsToDebug(hWndMdi));
       }
    }
 

--- a/src/lib/executioncontext.cpp
+++ b/src/lib/executioncontext.cpp
@@ -1135,14 +1135,14 @@ uint WINAPI FindModuleInLimbo(ModuleType moduleType, const char* name, Uninitial
  *                INVALID_HWND (-1) in case of errors
  */
 HWND WINAPI FindWindowHandle(const char* programName, ModuleType moduleType, const EXECUTION_CONTEXT* sec, const char* symbol, uint timeframe, BOOL isTesting, BOOL isVisualMode, BOOL isOptimization) {
-   if (sec) return sec->chart;                                 // with a super context return the inherited chart handle
+   if (sec) return sec->chart;                                    // with a super context return the inherited chart handle
 
    // situation:
    //  we are in the main module
    //  there's no super context
    //  MQL's WindowHandle() returned NULL
 
-   if ((isTesting && !isVisualMode) || isOptimization) {       // in these standard situations there's no chart
+   if ((isTesting && !isVisualMode) || isOptimization) {          // in these standard situations there's no chart
       return NULL;
    }
 
@@ -1157,7 +1157,7 @@ HWND WINAPI FindWindowHandle(const char* programName, ModuleType moduleType, con
    HWND hWndMdi  = GetDlgItem(hWndMain, IDC_MDI_CLIENT);
    if (!hWndMdi) return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MDIClient window not found (hWndMain=%p)", hWndMain));
 
-   HWND hChartWindow = NULL;                                   // chart system window holding the chart AfxFrameOrView
+   HWND hChartWindow = NULL;                                      // chart system window holding the chart AfxFrameOrView
 
    // indicator
    if (moduleType == MT_INDICATOR) {
@@ -1166,7 +1166,7 @@ HWND WINAPI FindWindowHandle(const char* programName, ModuleType moduleType, con
       //  Or we are a standalone indicator in a tester template:
       //   UI thread:     VisualMode=on|off (on VisualMode=off only indicator::init() is executed)
       //   non-UI thread: IsOptimization=on (only indicator::init() is executed)
-      if (!IsUIThread()) return NULL;                          // no chart for standalone indicator in tester template during optimization
+      if (!IsUIThread()) return NULL;                             // no chart for standalone indicator in tester template during optimization
 
       // WindowHandle() uses the title string to find a chart window. On execution of indicator::init() the window title may
       // not yet be set which results in the function returning NULL (can't find current window). However the window exists.
@@ -1176,13 +1176,13 @@ HWND WINAPI FindWindowHandle(const char* programName, ModuleType moduleType, con
       // If there's no last window in Z order without a title text, then the indicator was loaded by a tester template with
       // VisualMode=off (no chart window). In this case init() is executed but start() will never.
       //
-      HWND hWndChild = GetWindow(hWndMdi, GW_CHILD);           // first child in Z order (first chart)
-      if (!hWndChild) return NULL;                             // no MDIClient children => there is no chart: Tester with VisualMode=Off
+      HWND hWndChild = GetWindow(hWndMdi, GW_CHILD);              // first child in Z order (first chart)
+      if (!hWndChild) return NULL;                                // no MDIClient children => there is no chart: Tester with VisualMode=Off
 
-      HWND hWndLast = GetWindow(hWndChild, GW_HWNDLAST);       // last child in Z order (last chart)
-      if (GetWindowTextLength(hWndLast)) return NULL;          // last child already has a title => there is no chart: Tester with VisualMode=Off
+      HWND hWndLast = GetWindow(hWndChild, GW_HWNDLAST);          // last child in Z order (last chart)
+      if (GetWindowTextLength(hWndLast)) return NULL;             // last child already has a title => there is no chart: Tester with VisualMode=Off
 
-      hChartWindow = hWndLast;                                 // keep last chart (holding the chart AfxFrameOrView)
+      hChartWindow = hWndLast;                                    // keep last chart (holding the chart AfxFrameOrView)
    }
 
    // script
@@ -1191,34 +1191,34 @@ HWND WINAPI FindWindowHandle(const char* programName, ModuleType moduleType, con
       // solange Terminal/Chart nicht endgültig initialisiert sind. Ein laufendes Script wurde in diesem Fall über
       // die Konfiguration in "terminal-start.ini" gestartet und läuft im ersten passenden Chart in absoluter Reihenfolge
       // (CtrlID, nicht Z order).
-      HWND hWndChild = GetWindow(hWndMdi, GW_CHILD);           // first child window in Z order (top most chart window)
+      HWND hWndChild = GetWindow(hWndMdi, GW_CHILD);              // first child window in Z order (top-most chart window)
       if (!hWndChild) return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MDIClient window has no children in Script::init()  hWndMain=%p", hWndMain));
 
-      char chartDescription[MAX_CHARTDESCRIPTION_LENGTH + 1];
-      uint chars = ComposeChartTitle(symbol, timeframe, chartDescription, countof(chartDescription));
-      if (!chars) return INVALID_HWND;
-
-      char* title = NULL;
+      char *chartTitle = MakeChartTitleA(symbol, timeframe), *wndTitle = NULL;
+      if (!chartTitle) return INVALID_HWND;
       int id = INT_MAX;
 
-      while (hWndChild) {                                      // iterate over all child windows
-         free(title);
-         title = GetWindowTextA(hWndChild);                    // Here we can't use GetInternalWindowText() as the window
-         if (!title) return INVALID_HWND;                      // creation needs to finish before we get a valid response.
+      while (hWndChild) {                                         // iterate over all child windows
+         free(wndTitle);
+         wndTitle = GetWindowTextA(hWndChild);                    // Here we can't use GetInternalWindowText() as the window
+         if (!wndTitle) return _INVALID_HWND(bfree(chartTitle));  // creation needs to finish before we get a valid response.
 
-         if (StrEndsWith(title, " (offline)")) {
-            title[strlen(title)-10] = '\0';
+         if (StrEndsWith(wndTitle, " (offline)")) {
+            wndTitle[strlen(wndTitle)-10] = '\0';
          }
-         if (StrCompare(title, chartDescription)) {            // find all matching windows
-            id = std::min(id, GetDlgCtrlID(hWndChild));        // track the smallest in absolute order
-            if (!id) return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MDIClient child window %p has no control id", hWndChild), bfree(title));
+         if (StrCompare(wndTitle, chartTitle)) {                  // find all matching windows
+            id = std::min(id, GetDlgCtrlID(hWndChild));           // track the smallest in absolute order
+            if (!id) return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "MDIClient child %p has no control id", hWndChild), bfree(chartTitle, wndTitle));
          }
-         hWndChild = GetWindow(hWndChild, GW_HWNDNEXT);        // next child in Z order
+         hWndChild = GetWindow(hWndChild, GW_HWNDNEXT);           // next child in Z order
       }
-      free(title);
-      if (id == INT_MAX) return _INVALID_HWND(error(ERR_RUNTIME_ERROR, "no matching MDIClient child window found for \"%s\"", chartDescription));
+      if (id == INT_MAX) {
+         error(ERR_RUNTIME_ERROR, "no matching MDIClient child found for \"%s\"", chartTitle);
+         return _INVALID_HWND(bfree(chartTitle, wndTitle));
+      }
+      free(chartTitle, wndTitle);
 
-      hChartWindow = GetDlgItem(hWndMdi, id);                  // keep chart window (holding the chart AfxFrameOrView)
+      hChartWindow = GetDlgItem(hWndMdi, id);                     // keep chart window (holding the chart AfxFrameOrView)
    }
 
    // expert

--- a/src/lib/helper.cpp
+++ b/src/lib/helper.cpp
@@ -659,11 +659,11 @@ void WINAPI ReleaseWindowProperties() {
  * @param  char* symbol
  * @param  uint  timeframe
  *
- * @return char* - chart title description or a NULL pointer in case of errors
+ * @return string - chart title description or an empty string in case of errors
  */
-char* WINAPI MakeChartTitleA(const char* symbol, uint timeframe) {
+string WINAPI makeChartTitle(const char* symbol, uint timeframe) {
    size_t symbolLength = strlen(symbol);
-   if (!symbolLength || symbolLength > MAX_SYMBOL_LENGTH) return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter symbol: \"%s\"", symbol);
+   if (!symbolLength || symbolLength > MAX_SYMBOL_LENGTH) return _empty_str(error(ERR_INVALID_PARAMETER, "invalid parameter symbol: \"%s\"", symbol));
 
    char* sTimeframe = NULL;
 
@@ -690,9 +690,9 @@ char* WINAPI MakeChartTitleA(const char* symbol, uint timeframe) {
       case PERIOD_W1 : sTimeframe = "Weekly";  break;
       case PERIOD_MN1: sTimeframe = "Monthly"; break;
       default:
-         return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter timeframe: %d", timeframe);
+         return _empty_str(error(ERR_INVALID_PARAMETER, "invalid parameter timeframe: %d", timeframe));
    }
-   return asformat("%s,%s", symbol, sTimeframe);      // caller must free()
+   return string(symbol).append(",").append(sTimeframe);
 }
 
 

--- a/src/lib/helper.cpp
+++ b/src/lib/helper.cpp
@@ -654,45 +654,45 @@ void WINAPI ReleaseWindowProperties() {
 
 
 /**
- * Compose a description "<symbol>,<timeframe>" for the chart title bar (e.g. "EURUSD,Daily") and copy it to the passed buffer.
- * If the buffer is too small the string in the buffer is truncated. The string is always terminated with a NUL character.
+ * Return a description "<symbol>,<timeframe>" for the chart title bar (e.g. "EURUSD,Daily").
  *
  * @param  char* symbol
  * @param  uint  timeframe
- * @param  char* buffer
- * @param  uint  bufferSize
  *
- * @return uint - Amount of copied characters not counting the terminating NUL character or the passed parameter 'bufferSize'
- *                if the buffer is too small and the string in the buffer was truncated. NULL in case of errors.
+ * @return char* - chart title description or a NULL pointer in case of errors
  */
-uint WINAPI ComposeChartTitle(const char* symbol, uint timeframe, char* buffer, uint bufferSize) {
-   uint symbolLength = strlen(symbol);
-   if (!symbolLength || symbolLength > MAX_SYMBOL_LENGTH) return !error(ERR_INVALID_PARAMETER, "invalid parameter symbol: %s", DoubleQuoteStr(symbol));
-   if (!buffer)                                           return !error(ERR_INVALID_PARAMETER, "invalid parameter buffer: %p", buffer);
-   if ((int)bufferSize <= 0)                              return !error(ERR_INVALID_PARAMETER, "invalid parameter bufferSize: %d", bufferSize);
+char* WINAPI MakeChartTitleA(const char* symbol, uint timeframe) {
+   size_t symbolLength = strlen(symbol);
+   if (!symbolLength || symbolLength > MAX_SYMBOL_LENGTH) return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter symbol: \"%s\"", symbol);
 
    char* sTimeframe = NULL;
 
    switch (timeframe) {
       case PERIOD_M1 : sTimeframe = "M1";      break;
+      case PERIOD_M2 : sTimeframe = "M2";      break;
+      case PERIOD_M3 : sTimeframe = "M3";      break;
+      case PERIOD_M4 : sTimeframe = "M4";      break;
       case PERIOD_M5 : sTimeframe = "M5";      break;
+      case PERIOD_M6 : sTimeframe = "M6";      break;
+      case PERIOD_M10: sTimeframe = "M10";     break;
+      case PERIOD_M12: sTimeframe = "M12";     break;
       case PERIOD_M15: sTimeframe = "M15";     break;
+      case PERIOD_M20: sTimeframe = "M20";     break;
       case PERIOD_M30: sTimeframe = "M30";     break;
       case PERIOD_H1 : sTimeframe = "H1";      break;
+      case PERIOD_H2 : sTimeframe = "H2";      break;
+      case PERIOD_H3 : sTimeframe = "H3";      break;
       case PERIOD_H4 : sTimeframe = "H4";      break;
+      case PERIOD_H6 : sTimeframe = "H6";      break;
+      case PERIOD_H8 : sTimeframe = "H8";      break;
+      case PERIOD_H12: sTimeframe = "H12";     break;
       case PERIOD_D1 : sTimeframe = "Daily";   break;
       case PERIOD_W1 : sTimeframe = "Weekly";  break;
       case PERIOD_MN1: sTimeframe = "Monthly"; break;
       default:
-         return !error(ERR_INVALID_PARAMETER, "invalid parameter timeframe: %d", timeframe);
+         return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter timeframe: %d", timeframe);
    }
-   uint chars = snprintf(buffer, bufferSize, "%s,%s", symbol, sTimeframe);
-
-   if (chars < 0 || chars==bufferSize) {
-      buffer[chars-1] = 0;
-      return bufferSize;
-   }
-   return chars;
+   return asformat("%s,%s", symbol, sTimeframe);      // caller must free()
 }
 
 

--- a/src/lib/log.cpp
+++ b/src/lib/log.cpp
@@ -68,7 +68,7 @@ BOOL WINAPI AppendLogMessageA(EXECUTION_CONTEXT* ec, time32 serverTime, const ch
    string sLoglevel(level==LOG_DEBUG ? "": LoglevelDescriptionA(level));                  // loglevel (LOG_DEBUG is blanked out)
    string sExecPath(master->programName); sExecPath.append("::");                         // execution path
    if (ec->moduleType == MT_LIBRARY) sExecPath.append(ec->moduleName).append("::");       //
-   string sMessage(message); StrReplace(StrReplace(sMessage, "\r\n", " "), "\n", " ");    // replace linebreaks with spaces
+   string sMessage(message); strReplace(strReplace(sMessage, "\r\n", " "), "\n", " ");    // replace linebreaks with spaces
    string sError; if (error) sError.append("  [").append(ErrorToStrA(error)).append("]"); // append error description
 
    if (master->testing) {                                                                 // tester:

--- a/src/lib/string.cpp
+++ b/src/lib/string.cpp
@@ -74,7 +74,7 @@ std::istream& getline(std::istream &is, std::string &line) {
       }
       line += (char)ch;
    }
-   return(is);
+   return is;
 
    /*
    char* fileName = "terminal-config.ini";
@@ -142,10 +142,10 @@ int __cdecl CompareMqlStringsA(const void* first, const void* second) {
    MqlStringA* s1 = (MqlStringA*) first;
    MqlStringA* s2 = (MqlStringA*) second;
 
-   if (s1 == s2) return( 0);
-   if (!s1)      return(-1);
-   if (!s2)      return(+1);
-   return(strcmp(s1->value, s2->value));
+   if (s1 == s2) return  0;
+   if (!s1)      return -1;
+   if (!s2)      return +1;
+   return strcmp(s1->value, s2->value);
 }
 
 
@@ -163,10 +163,10 @@ int __cdecl CompareMqlStringsW(const void* first, const void* second) {
    MqlStringW* s1 = (MqlStringW*) first;
    MqlStringW* s2 = (MqlStringW*) second;
 
-   if (s1 == s2) return( 0);
-   if (!s1)      return(-1);
-   if (!s2)      return(+1);
-   return(wstrcmp(s1->value, s2->value));
+   if (s1 == s2) return  0;
+   if (!s1)      return -1;
+   if (!s2)      return +1;
+   return wstrcmp(s1->value, s2->value);
 }
 
 
@@ -179,12 +179,12 @@ int __cdecl CompareMqlStringsW(const void* first, const void* second) {
  * @return BOOL - success status
  */
 BOOL WINAPI SortMqlStringsA(MqlStringA strings[], int size) {
-   if ((uint)strings < MIN_VALID_POINTER) return(!error(ERR_INVALID_PARAMETER, "invalid parameter strings: 0x%p (not a valid pointer)", strings));
-   if (size <= 0)                         return(!error(ERR_INVALID_PARAMETER, "invalid parameter size: %d", size));
-   if (size == 1) return(TRUE);           // nothing to do
+   if ((uint)strings < MIN_VALID_POINTER) return !error(ERR_INVALID_PARAMETER, "invalid parameter strings: 0x%p (not a valid pointer)", strings);
+   if (size <= 0)                         return !error(ERR_INVALID_PARAMETER, "invalid parameter size: %d", size);
+   if (size == 1) return TRUE;            // nothing to do
 
    qsort(strings, size, sizeof(MqlStringA), CompareMqlStringsA);
-   return(TRUE);
+   return TRUE;
    #pragma EXPANDER_EXPORT
 }
 
@@ -198,9 +198,9 @@ BOOL WINAPI SortMqlStringsA(MqlStringA strings[], int size) {
  * @return BOOL - success status
  */
 BOOL WINAPI SortMqlStringsW(MqlStringW strings[], int size) {
-   if ((uint)strings < MIN_VALID_POINTER) return(!error(ERR_INVALID_PARAMETER, "invalid parameter strings: 0x%p (not a valid pointer)", strings));
-   if (size <= 0)                         return(!error(ERR_INVALID_PARAMETER, "invalid parameter size: %d", size));
-   if (size == 1) return(TRUE);           // nothing to do
+   if ((uint)strings < MIN_VALID_POINTER) return !error(ERR_INVALID_PARAMETER, "invalid parameter strings: 0x%p (not a valid pointer)", strings);
+   if (size <= 0)                         return !error(ERR_INVALID_PARAMETER, "invalid parameter size: %d", size);
+   if (size == 1) return TRUE;            // nothing to do
 
    qsort(strings, size, sizeof(MqlStringW), CompareMqlStringsW);
    return TRUE;
@@ -261,17 +261,18 @@ BOOL WINAPI StrIsNull(const char* value) {
  * @return BOOL
  */
 BOOL WINAPI StrStartsWith(const char* str, const char* prefix) {
-   if (!str)          return(FALSE);
-   if (!prefix)       return(!error(ERR_INVALID_PARAMETER, "invalid parameter prefix: %s", prefix));
-   if (str == prefix) return(TRUE);       // if pointers are equal values are too
+   if (!str)          return FALSE;
+   if (!prefix)       return !error(ERR_INVALID_PARAMETER, "invalid parameter prefix: %s", prefix);
+   if (str == prefix) return TRUE;        // if pointers are equal values are too
 
    uint strLen    = strlen(str);
    uint prefixLen = strlen(prefix);
-   if (!prefixLen) return(!error(ERR_INVALID_PARAMETER, "invalid parameter prefix: \"\""));
+   if (!prefixLen) return !error(ERR_INVALID_PARAMETER, "invalid parameter prefix: \"\"");
 
-   if (strLen >= prefixLen)
-      return(strncmp(str, prefix, prefixLen) == 0);
-   return(FALSE);
+   if (strLen >= prefixLen) {
+      return (strncmp(str, prefix, prefixLen) == 0);
+   }
+   return FALSE;
    #pragma EXPANDER_EXPORT
 }
 
@@ -285,17 +286,18 @@ BOOL WINAPI StrStartsWith(const char* str, const char* prefix) {
  * @return BOOL
  */
 BOOL WINAPI StrStartsWith(const wchar* str, const wchar* prefix) {
-   if (!str)          return(FALSE);
-   if (!prefix)       return(!error(ERR_INVALID_PARAMETER, "invalid parameter prefix: %S", prefix));
-   if (str == prefix) return(TRUE);       // if pointers are equal values are too
+   if (!str)          return FALSE;
+   if (!prefix)       return !error(ERR_INVALID_PARAMETER, "invalid parameter prefix: %S", prefix);
+   if (str == prefix) return TRUE;        // if pointers are equal values are too
 
    uint strLen    = wstrlen(str);
    uint prefixLen = wstrlen(prefix);
-   if (!prefixLen) return(!error(ERR_INVALID_PARAMETER, "invalid parameter prefix: \"\""));
+   if (!prefixLen) return !error(ERR_INVALID_PARAMETER, "invalid parameter prefix: \"\"");
 
-   if (strLen >= prefixLen)
-      return(wcsncmp(str, prefix, prefixLen) == 0);
-   return(FALSE);
+   if (strLen >= prefixLen) {
+      return (wcsncmp(str, prefix, prefixLen) == 0);
+   }
+   return FALSE;
 }
 
 
@@ -308,17 +310,18 @@ BOOL WINAPI StrStartsWith(const wchar* str, const wchar* prefix) {
  * @return BOOL
  */
 BOOL WINAPI StrEndsWith(const char* str, const char* suffix) {
-   if (!str)          return(FALSE);
-   if (!suffix)       return(!error(ERR_INVALID_PARAMETER, "invalid parameter suffix: %s", suffix));
-   if (str == suffix) return(TRUE);       // if pointers are equal values are too
+   if (!str)          return FALSE;
+   if (!suffix)       return !error(ERR_INVALID_PARAMETER, "invalid parameter suffix: %s", suffix);
+   if (str == suffix) return TRUE;        // if pointers are equal values are too
 
    uint strLen    = strlen(str);
    uint suffixLen = strlen(suffix);
-   if (!suffixLen) return(!error(ERR_INVALID_PARAMETER, "invalid parameter suffix: \"\""));
+   if (!suffixLen) return !error(ERR_INVALID_PARAMETER, "invalid parameter suffix: \"\"");
 
-   if (strLen >= suffixLen)
-      return(strcmp(str + strLen - suffixLen, suffix) == 0);
-   return(FALSE);
+   if (strLen >= suffixLen) {
+      return (strcmp(str + strLen - suffixLen, suffix) == 0);
+   }
+   return FALSE;
    #pragma EXPANDER_EXPORT
 }
 
@@ -332,17 +335,18 @@ BOOL WINAPI StrEndsWith(const char* str, const char* suffix) {
  * @return BOOL
  */
 BOOL WINAPI StrEndsWithI(const char* str, const char* suffix) {
-   if (!str)          return(FALSE);
-   if (!suffix)       return(!error(ERR_INVALID_PARAMETER, "invalid parameter suffix: %s", suffix));
-   if (str == suffix) return(TRUE);       // if pointers are equal values are too
+   if (!str)          return FALSE;
+   if (!suffix)       return !error(ERR_INVALID_PARAMETER, "invalid parameter suffix: %s", suffix);
+   if (str == suffix) return TRUE;        // if pointers are equal values are too
 
    uint strLen    = strlen(str);
    uint suffixLen = strlen(suffix);
-   if (!suffixLen) return(!error(ERR_INVALID_PARAMETER, "invalid parameter suffix: \"\""));
+   if (!suffixLen) return !error(ERR_INVALID_PARAMETER, "invalid parameter suffix: \"\"");
 
-   if (strLen >= suffixLen)
-      return(stricmp(str + strLen - suffixLen, suffix) == 0);
-   return(FALSE);
+   if (strLen >= suffixLen) {
+      return (stricmp(str + strLen - suffixLen, suffix) == 0);
+   }
+   return FALSE;
    #pragma EXPANDER_EXPORT
 }
 
@@ -397,6 +401,54 @@ BOOL WINAPI StrEndsWithI(const wchar* str, const wchar* suffix) {
 
 
 /**
+ * Return the left part of a string up to the specified occurrence of a limiting substring.
+ * The result does not include the limiting substring.
+ *
+ * @param  string subject          - initial string
+ * @param  string limiter          - limiting substring (if empty the entire string is returned)
+ * @param  int    count [optional] - Number of occurrences of the limiting substring (default: 1).
+ *                                    positive: counted from the start of the string
+ *                                    negative: counted from the end of the string
+ *                                    0:        an empty string is returned
+ *                                   If the absolute number exceeds the number of occurrences, the entire string is returned.
+ * @return string - new string
+ */
+string WINAPI strLeftTo(const string &subject, const string &limiter, int count/*= 1*/) {
+   size_t subjectLength = subject.length(), limiterLength = limiter.length();
+
+   if (!subjectLength) return subject;
+   if (!limiterLength) return subject;
+   if (!count)         return string();
+
+   if (count > 0) {
+      size_t offset = 0;
+      for (int i=0; i < count; i++) {
+         size_t pos = subject.find(limiter, offset);
+         if (pos == string::npos) {
+            return subject;                  // fewer occurrences than count
+         }
+         offset = pos + limiterLength;
+      }
+      return subject.substr(0, offset - limiterLength);
+   }
+   else {
+      size_t offset = subjectLength;
+      for (int i=0; i < -count; i++) {
+         if (offset < limiterLength) {
+            return subject;                  // fewer occurrences than count
+         }
+         size_t pos = subject.rfind(limiter, offset - limiterLength);
+         if (pos == string::npos) {
+            return subject;                  // fewer occurrences than count
+         }
+         offset = pos;
+      }
+      return subject.substr(0, offset);
+   }
+}
+
+
+/**
  * Replace a substring of a string by another substring. The function modifies the string.
  *
  * @param  _InOut_ string &subject         - string to process
@@ -406,15 +458,15 @@ BOOL WINAPI StrEndsWithI(const wchar* str, const wchar* suffix) {
  *
  * @return string& - the same string
  */
-string& WINAPI StrReplace(string &subject, const string &search, const string &replace, size_t count/*=INT_MAX*/) {
+string& WINAPI strReplace(string &subject, const string &search, const string &replace, size_t count/*= INT_MAX*/) {
    size_t subjectLen = subject.length();
-   if (!subjectLen) return(subject);
+   if (!subjectLen) return subject;
 
    size_t searchLen = search.length();
-   if (!searchLen) return(subject);
+   if (!searchLen) return subject;
 
    size_t replaceLen = replace.length();
-   if (subjectLen < searchLen || !search.compare(replace)) return(subject);
+   if (subjectLen < searchLen || !search.compare(replace)) return subject;
 
    size_t replacements = 0, pos = 0;
    while (replacements < count && (pos = subject.find(search, pos)) != string::npos) {
@@ -428,7 +480,7 @@ string& WINAPI StrReplace(string &subject, const string &search, const string &r
       pos += replaceLen;
       ++replacements;
    }
-   return(subject);
+   return subject;
 }
 
 
@@ -496,7 +548,7 @@ wstring& WINAPI strToLower(wstring &str) {
    for (size_t i=0, n=str.length(); i < n; i++) {
       str[i] = towlower(str[i]);
    }
-   return(str);
+   return str;
 }
 
 
@@ -576,7 +628,7 @@ wstring& WINAPI strToUpper(wstring &str) {
  * @return char* - the same string
  */
 char* WINAPI strim(char* str) {
-   return(strim_left(strim_right(str)));
+   return strim_left(strim_right(str));
 }
 
 
@@ -588,7 +640,7 @@ char* WINAPI strim(char* str) {
  * @return string& - the same string
  */
 string& WINAPI strim(string &str) {
-   return(strim_left(strim_right(str)));
+   return strim_left(strim_right(str));
 }
 
 
@@ -676,7 +728,7 @@ string& WINAPI strim_right(string &str) {
  * @return wchar* - the same string
  */
 wchar* WINAPI wstrim(wchar* str) {
-   return(wstrim_left(wstrim_right(str)));
+   return wstrim_left(wstrim_right(str));
 }
 
 
@@ -688,7 +740,7 @@ wchar* WINAPI wstrim(wchar* str) {
  * @return wstring& - the same string
  */
 wstring& WINAPI wstrim(wstring &str) {
-   return(wstrim_left(wstrim_right(str)));
+   return wstrim_left(wstrim_right(str));
 }
 
 
@@ -1055,8 +1107,7 @@ string WINAPI utf16ToUtf8(const wstring &wstr) {
          return str;
       }
    }
-   error(ERR_WIN32_ERROR + GetLastError(), "cannot convert UTF-16 string to UTF-8: \"%S\"", wstr.c_str());
-   return string();
+   return _empty_str(error(ERR_WIN32_ERROR + GetLastError(), "cannot convert UTF-16 string to UTF-8: \"%S\"", wstr.c_str()));
 }
 
 
@@ -1070,8 +1121,7 @@ string WINAPI utf16ToUtf8(const wstring &wstr) {
  * @return char* - formatted string or a NULL pointer in case of errors
  */
 char* __cdecl asformat(const char* format, ...) {
-   if (!format)  return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: (null)");
-   if (!*format) return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: \"\" (empty)");
+   if (!format) return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: (null)");
 
    va_list args;
    va_start(args, format);
@@ -1092,15 +1142,14 @@ char* __cdecl asformat(const char* format, ...) {
  * @return wchar* - formatted string or a NULL pointer in case of errors
  */
 wchar* __cdecl asformat(const wchar* format, ...) {
-   if (!format)  return((wchar*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: (null)"));
-   if (!*format) return((wchar*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: \"\" (empty)"));
+   if (!format) return (wchar*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: (null)");
 
    va_list args;
    va_start(args, format);
    wchar* result = _asformat(format, args);
    va_end(args);
 
-   return(result);                              // caller must free()
+   return result;                               // caller must free()
 }
 
 
@@ -1112,16 +1161,12 @@ wchar* __cdecl asformat(const wchar* format, ...) {
  * @param  va_list &args  - variable list of arguments (may contain UTF-16 strings)
  *
  * @return char* - formatted string or NULL in case of errors
- *
- * @see  https://learn.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-170
- * @see  https://www.tutorialspoint.com/format-specifiers-in-c
  */
 char* WINAPI _asformat(const char* format, const va_list &args) {
-   if (!format)  return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: (null)");
-   if (!*format) return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: \"\" (empty)");
+   if (!format) return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: (null)");
 
    uint size = vscprintf(format, args) + 1;     // +1 for the terminating NUL char
-   char* buffer = (char*)malloc(size);
+   char* buffer = (char*) malloc(size);
    if (buffer) {
       vsprintf_s(buffer, size, format, args);
    }
@@ -1137,13 +1182,9 @@ char* WINAPI _asformat(const char* format, const va_list &args) {
  * @param  va_list &args  - variable list of arguments (may contain ANSI strings)
  *
  * @return wchar* - formatted string or NULL in case of errors
- *
- * @see  https://learn.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-170
- * @see  https://www.tutorialspoint.com/format-specifiers-in-c
  */
 wchar* WINAPI _asformat(const wchar* format, const va_list &args) {
-   if (!format)  return (wchar*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: (null)");
-   if (!*format) return (wchar*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: \"\" (empty)");
+   if (!format) return (wchar*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: (null)");
 
    uint size = vwscprintf(format, args) + 1;       // +1 for the terminating NUL wchar
    wchar* buffer = (wchar*)malloc(size * sizeof(wchar));

--- a/src/lib/string.cpp
+++ b/src/lib/string.cpp
@@ -1067,10 +1067,7 @@ string WINAPI utf16ToUtf8(const wstring &wstr) {
  * @param  char* format - string with format codes (see Microsoft extension for ANSI/UTF-16 specific codes)
  * @param        ...    - variable number of arguments (may contain UTF-16 strings)
  *
- * @return char* - formatted string or NULL in case of errors
- *
- * @see  https://learn.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-170
- * @see  https://www.tutorialspoint.com/format-specifiers-in-c
+ * @return char* - formatted string or a NULL pointer in case of errors
  */
 char* __cdecl asformat(const char* format, ...) {
    if (!format)  return (char*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: (null)");
@@ -1081,7 +1078,7 @@ char* __cdecl asformat(const char* format, ...) {
    char* result = _asformat(format, args);
    va_end(args);
 
-   return result;                   // caller must free()
+   return result;                               // caller must free()
 }
 
 
@@ -1092,10 +1089,7 @@ char* __cdecl asformat(const char* format, ...) {
  * @param  wchar* format - string with format codes (see Microsoft extension for ANSI/UTF-16 specific codes)
  * @param         ...    - variable number of arguments (may contain ANSI strings)
  *
- * @return wchar* - formatted string or NULL in case of errors
- *
- * @see  https://learn.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-170
- * @see  https://www.tutorialspoint.com/format-specifiers-in-c
+ * @return wchar* - formatted string or a NULL pointer in case of errors
  */
 wchar* __cdecl asformat(const wchar* format, ...) {
    if (!format)  return((wchar*)!error(ERR_INVALID_PARAMETER, "invalid parameter format: (null)"));

--- a/src/lib/terminal.cpp
+++ b/src/lib/terminal.cpp
@@ -786,18 +786,15 @@ HWND WINAPI GetTerminalMainWindow() {
       wchar* className = NULL;
       uint i = 0;
 
-      // MQL scripts run in their own thread. On fast CPUs with multiple cores, a race condition may occur when the
-      // Expander starts or when a script is launched via terminal startup configuration ("start.ini"):
+      // MQL scripts run in their own thread. On fast CPUs with multiple cores, the following race condition may occur when
+      // the Expander is loaded early: A non-UI thread is already looking-up the terminal main window, even though the UI
+      // thread has not yet had enough time to create it.
       //
-      // A non-UI thread is already looking-up the terminal main window, even though the UI thread has not yet had enough
-      // time to create it. This can occur particularly in terminals of build <= 509. Starting with build 600, thread
-      // synchronization has changed.
-      //
-      // Workaround: In such a case, the calling thread enters a brief wait loop. This is not critical, as normal MQL
-      // programs and the UI thread itself never enter this loop.
+      // Workaround: In such a case, the calling thread enters a brief wait loop. This is not critical, as MQL programs or
+      // the UI thread itself will never enter this loop.
 
       while (TRUE) {
-         hWndNext = GetTopWindow(NULL);
+         hWndNext = GetTopWindow(NULL);            // TODO: use EnumWindows() as a Z order change will corrupt the result
 
          while (hWndNext) {                        // iterate over all top-level windows
             GetWindowThreadProcessId(hWndNext, &processId);


### PR DESCRIPTION
On terminal builds <= 509 an auto-start script configured in the terminal startup configuration (`"start.ini"`) could cause

`No matching MDIClient child window found for "Symbol,Period" [ERR_RUNTIME_ERROR]`

@codex review
