### PR TITLE
Fix a hanging UI thread dispatcher

### DIFF
--- a/header/lib/thread.h
+++ b/header/lib/thread.h
@@ -22,8 +22,10 @@ struct JOB {
          return result = 0;
       }
 
+      SetLastError(NO_ERROR);
       result = func(args);
       last_error = GetLastError();
+
       SetEvent(event);
       return result;
    }

--- a/header/lib/thread.h
+++ b/header/lib/thread.h
@@ -2,36 +2,35 @@
 #include "expander.h"
 
 // callback function signature used by InvokeUiThread()
-typedef LRESULT (CALLBACK *UiThreadCallback)(LPARAM args);
+typedef LRESULT (CALLBACK *UiThreadCallback)(void* args);
 
 // transport of callback details for the UI-thread dispatcher
 struct JOB {
    UiThreadCallback func;        // function pointer
-   LPARAM           args;        // argument pointer
+   void*            args;        // argument pointer
    LRESULT          result;      // return value
-   HANDLE           done;        // optional completion event, without it: fire-and-forget
+   HANDLE           event;       // completion event
    int              last_error;  // last job execution error (if any)
-   bool             owner;       // if true, run() deletes itself (this job) after execution
 
    LRESULT run() {               // executes the job
-      if (func) {
-         result = func(args);
-         last_error = GetLastError();
+      if (!func) {
+         last_error = error(ERR_INVALID_PARAMETER, "invalid job function: (null)");
+         return result = 0;
       }
-      else {
-         result = 0;
-         last_error = error(ERR_INVALID_PARAMETER, "invalid job function: 0x%p");
+      if (!event) {
+         last_error = error(ERR_INVALID_PARAMETER, "invalid completion event: (null)");
+         return result = 0;
       }
-      if (done) SetEvent(done);
 
-      LRESULT retValue = result; // copy before potential self-delete
-      if (owner) delete this;
-      return retValue;
+      result = func(args);
+      last_error = GetLastError();
+      SetEvent(event);
+      return result;
    }
 };
 
 
 DWORD   WINAPI GetUiThreadId();
 BOOL    WINAPI IsUiThread(DWORD threadId = NULL);
-LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait = false);
+LRESULT WINAPI InvokeUiThread(UiThreadCallback func, void* args);
 DWORD   WINAPI SetLastErrorEx(DWORD error);

--- a/header/lib/thread.h
+++ b/header/lib/thread.h
@@ -1,17 +1,17 @@
 #pragma once
 #include "expander.h"
 
-// callback function signature used by UiInvoke()
-typedef LRESULT (CALLBACK *UiInvokeProc)(LPARAM args);
+// callback function signature used by InvokeUiThread()
+typedef LRESULT (CALLBACK *UiThreadCallback)(LPARAM args);
 
 // transport of callback details for the UI-thread dispatcher
 struct JOB {
-   UiInvokeProc func;            // function pointer
-   LPARAM       args;            // argument pointer
-   LRESULT      result;          // return value
-   HANDLE       done;            // optional completion event, without it: fire-and-forget
-   int          error;           // job execution error (if any)
-   bool         owner;           // if true, run() deletes itself (this job) after execution
+   UiThreadCallback func;        // function pointer
+   LPARAM           args;        // argument pointer
+   LRESULT          result;      // return value
+   HANDLE           done;        // optional completion event, without it: fire-and-forget
+   int              error;       // job execution error (if any)
+   bool             owner;       // if true, run() deletes itself (this job) after execution
 
    LRESULT run() {               // executes the job
       if (func) {
@@ -32,5 +32,5 @@ struct JOB {
 
 DWORD   WINAPI GetUiThreadId();
 BOOL    WINAPI IsUiThread(DWORD threadId = NULL);
-LRESULT WINAPI UiInvoke(UiInvokeProc func, LPARAM args, bool wait = false);
+LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait = false);
 DWORD   WINAPI SetLastErrorEx(DWORD error);

--- a/header/lib/thread.h
+++ b/header/lib/thread.h
@@ -10,16 +10,17 @@ struct JOB {
    LPARAM           args;        // argument pointer
    LRESULT          result;      // return value
    HANDLE           done;        // optional completion event, without it: fire-and-forget
-   int              error;       // job execution error (if any)
+   int              last_error;  // last job execution error (if any)
    bool             owner;       // if true, run() deletes itself (this job) after execution
 
    LRESULT run() {               // executes the job
       if (func) {
          result = func(args);
+         last_error = GetLastError();
       }
       else {
-         error = error(ERR_INVALID_PARAMETER, "invalid job function: 0x%p");
          result = 0;
+         last_error = error(ERR_INVALID_PARAMETER, "invalid job function: 0x%p");
       }
       if (done) SetEvent(done);
 

--- a/header/lib/thread.h
+++ b/header/lib/thread.h
@@ -9,7 +9,7 @@ struct JOB {
    UiThreadCallback func;        // function pointer
    void*            args;        // argument pointer
    LRESULT          result;      // return value
-   HANDLE           event;       // completion event
+   HANDLE           completion;  // completion event
    int              last_error;  // last job execution error (if any)
 
    LRESULT run() {               // executes the job
@@ -17,7 +17,7 @@ struct JOB {
          last_error = error(ERR_INVALID_PARAMETER, "invalid job function: (null)");
          return result = 0;
       }
-      if (!event) {
+      if (!completion) {
          last_error = error(ERR_INVALID_PARAMETER, "invalid completion event: (null)");
          return result = 0;
       }
@@ -26,7 +26,7 @@ struct JOB {
       result = func(args);
       last_error = GetLastError();
 
-      SetEvent(event);
+      SetEvent(completion);
       return result;
    }
 };

--- a/header/lib/ui/integration.h
+++ b/header/lib/ui/integration.h
@@ -1,12 +1,12 @@
 #pragma once
 #include "expander.h"
 
-BOOL           WINAPI   SetupUiIntegration();
+BOOL           WINAPI   IntegrateExpander();
 static BOOL    WINAPI   RegisterWindowEventHook();
 static LRESULT CALLBACK WindowEventHook(int type, WPARAM wParam, LPARAM lParam);
 
-static BOOL    WINAPI   NotifyUiThread();
-static LRESULT CALLBACK UiThreadHook(int code, WPARAM wParam, LPARAM lParam);
+static BOOL    WINAPI   HookUiThread();
+static LRESULT CALLBACK UiThreadHookProc(int code, WPARAM wParam, LPARAM lParam);
 
 static BOOL    WINAPI   SubclassMainWindow();
 static LRESULT CALLBACK MainWindowSubclassProc(HWND hWnd, uint msg, WPARAM wParam,LPARAM lParam, UINT_PTR subclassId, DWORD_PTR data);

--- a/header/lib/ui/integration.h
+++ b/header/lib/ui/integration.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "expander.h"
 
+#define PROP_WINDOW_SUBCLASSED L"rsfMT4Expander.subclassed"
+
+
 BOOL           WINAPI   IntegrateExpander();
 static BOOL    WINAPI   RegisterWindowEventHook();
 static LRESULT CALLBACK WindowEventHook(int type, WPARAM wParam, LPARAM lParam);

--- a/src/dev/dev.cpp
+++ b/src/dev/dev.cpp
@@ -46,12 +46,14 @@ HWND WINAPI Test_CreateStatic(uint pid) {
    struct ARGS {
       __in  HWND hWndParent;
       __out int  error;
-   } args = { ec->chart, NO_ERROR };
+   } _args = { ec->chart, NO_ERROR };
+   ARGS* args = new ARGS(_args);                      // passed args must be heap-allocated in case InvokeUiThread() fails
 
    // create the child control
    SetLastError(NO_ERROR);
-   HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildControl, (LPARAM)&args, true);
-   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, (int)GetLastError()), "CreateChildControl()");
+   HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildControl, (LPARAM)args, true);
+   if (!hWndChild || args->error) return (HWND)!error(orElse(args->error, (int)GetLastError()), "CreateChildControl()");
+   delete args;
 
    SetWindowPos(hWndChild, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
    debug("child control created: %p", hWndChild);
@@ -112,12 +114,14 @@ HWND WINAPI Test_CreateWindow(uint pid) {
       __in  HWND         hWndParent;
       __in  const wchar* className;
       __out int          error;
-   } args = { ec->chart, className, NO_ERROR };
+   } _args = { ec->chart, className, NO_ERROR };
+   ARGS* args = new ARGS(_args);                      // passed args must be heap-allocated in case InvokeUiThread() fails
 
    // create the child window
    SetLastError(NO_ERROR);
-   HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildWindow, (LPARAM)&args, true);
-   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, (int)GetLastError()), "CreateChildWindow()");
+   HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildWindow, (LPARAM)args, true);
+   if (!hWndChild || args->error) return (HWND)!error(orElse(args->error, (int)GetLastError()), "CreateChildWindow()");
+   delete args;
 
    SetWindowPos(hWndChild, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
    debug("child window created: %p", hWndChild);

--- a/src/dev/dev.cpp
+++ b/src/dev/dev.cpp
@@ -112,7 +112,7 @@ HWND WINAPI Test_CreateWindow(uint pid) {
    };
    struct ARGS {
       __in  HWND         hWndParent;
-      __in  const wchar* className;
+      __in  const wchar* className;                   // points to static storage
       __out int          error;
    } _args = { ec->chart, className, NO_ERROR };
    ARGS* args = new ARGS(_args);                      // passed args must be heap-allocated in case InvokeUiThread() fails

--- a/src/dev/dev.cpp
+++ b/src/dev/dev.cpp
@@ -49,7 +49,7 @@ HWND WINAPI Test_CreateStatic(uint pid) {
    } args = { ec->chart, NO_ERROR };
 
    // create the child control
-   HWND hWndChild = (HWND) UiInvoke(local::CreateChildControl, (LPARAM)&args, true);
+   HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildControl, (LPARAM)&args, true);
    if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, ERR_RUNTIME_ERROR), "CreateChildControl()");
 
    SetWindowPos(hWndChild, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
@@ -114,7 +114,7 @@ HWND WINAPI Test_CreateWindow(uint pid) {
    } args = { ec->chart, className, NO_ERROR };
 
    // create the child window
-   HWND hWndChild = (HWND) UiInvoke(local::CreateChildWindow, (LPARAM)&args, true);
+   HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildWindow, (LPARAM)&args, true);
    if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, ERR_RUNTIME_ERROR), "CreateChildWindow()");
 
    SetWindowPos(hWndChild, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);

--- a/src/dev/dev.cpp
+++ b/src/dev/dev.cpp
@@ -51,7 +51,7 @@ HWND WINAPI Test_CreateStatic(uint pid) {
    // create the child control
    SetLastError(NO_ERROR);
    HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildControl, (LPARAM)&args, true);
-   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, ERR_RUNTIME_ERROR), "CreateChildControl()");
+   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, (int)(ERR_WIN32_ERROR + GetLastError())), "CreateChildControl()");
 
    SetWindowPos(hWndChild, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
    debug("child control created: %p", hWndChild);
@@ -117,7 +117,7 @@ HWND WINAPI Test_CreateWindow(uint pid) {
    // create the child window
    SetLastError(NO_ERROR);
    HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildWindow, (LPARAM)&args, true);
-   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, ERR_RUNTIME_ERROR), "CreateChildWindow()");
+   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, (int)(ERR_WIN32_ERROR + GetLastError())), "CreateChildWindow()");
 
    SetWindowPos(hWndChild, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
    debug("child window created: %p", hWndChild);

--- a/src/dev/dev.cpp
+++ b/src/dev/dev.cpp
@@ -51,7 +51,7 @@ HWND WINAPI Test_CreateStatic(uint pid) {
    // create the child control
    SetLastError(NO_ERROR);
    HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildControl, (LPARAM)&args, true);
-   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, (int)(ERR_WIN32_ERROR + GetLastError())), "CreateChildControl()");
+   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, (int)GetLastError()), "CreateChildControl()");
 
    SetWindowPos(hWndChild, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
    debug("child control created: %p", hWndChild);
@@ -117,7 +117,7 @@ HWND WINAPI Test_CreateWindow(uint pid) {
    // create the child window
    SetLastError(NO_ERROR);
    HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildWindow, (LPARAM)&args, true);
-   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, (int)(ERR_WIN32_ERROR + GetLastError())), "CreateChildWindow()");
+   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, (int)GetLastError()), "CreateChildWindow()");
 
    SetWindowPos(hWndChild, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
    debug("child window created: %p", hWndChild);

--- a/src/dev/dev.cpp
+++ b/src/dev/dev.cpp
@@ -23,8 +23,8 @@ HWND WINAPI Test_CreateStatic(uint pid) {
 
    // creation callback and arguments
    struct local {
-      static LRESULT CALLBACK CreateChildControl(LPARAM lParam) {
-         ARGS* args = (ARGS*)lParam;
+      static LRESULT CALLBACK CreateChildControl(void* _args) {
+         ARGS* args = (ARGS*)_args;
          if (!args) return !error(ERR_INVALID_POINTER, "invalid arguments: NULL");
 
          DWORD styles = WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS| SS_LEFT | SS_NOPREFIX;
@@ -46,14 +46,12 @@ HWND WINAPI Test_CreateStatic(uint pid) {
    struct ARGS {
       __in  HWND hWndParent;
       __out int  error;
-   } _args = { ec->chart, NO_ERROR };
-   ARGS* args = new ARGS(_args);                      // passed args must be heap-allocated in case InvokeUiThread() fails
+   } args = { ec->chart, NO_ERROR };
 
    // create the child control
    SetLastError(NO_ERROR);
-   HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildControl, (LPARAM)args, true);
-   if (!hWndChild || args->error) return (HWND)!error(orElse(args->error, (int)GetLastError()), "CreateChildControl()");
-   delete args;
+   HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildControl, (void*)&args);
+   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, (int)GetLastError()), "CreateChildControl()");
 
    SetWindowPos(hWndChild, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
    debug("child control created: %p", hWndChild);
@@ -90,8 +88,8 @@ HWND WINAPI Test_CreateWindow(uint pid) {
 
    // creation callback and arguments
    struct local {
-      static LRESULT CALLBACK CreateChildWindow(LPARAM lParam) {
-         ARGS* args = (ARGS*)lParam;
+      static LRESULT CALLBACK CreateChildWindow(void* _args) {
+         ARGS* args = (ARGS*)_args;
          if (!args) return !error(ERR_INVALID_POINTER, "invalid arguments: NULL");
 
          DWORD styles = WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS;
@@ -112,16 +110,14 @@ HWND WINAPI Test_CreateWindow(uint pid) {
    };
    struct ARGS {
       __in  HWND         hWndParent;
-      __in  const wchar* className;                   // points to static storage
+      __in  const wchar* className;
       __out int          error;
-   } _args = { ec->chart, className, NO_ERROR };
-   ARGS* args = new ARGS(_args);                      // passed args must be heap-allocated in case InvokeUiThread() fails
+   } args = { ec->chart, className, NO_ERROR };
 
    // create the child window
    SetLastError(NO_ERROR);
-   HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildWindow, (LPARAM)args, true);
-   if (!hWndChild || args->error) return (HWND)!error(orElse(args->error, (int)GetLastError()), "CreateChildWindow()");
-   delete args;
+   HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildWindow, &args);
+   if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, (int)GetLastError()), "CreateChildWindow()");
 
    SetWindowPos(hWndChild, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
    debug("child window created: %p", hWndChild);

--- a/src/dev/dev.cpp
+++ b/src/dev/dev.cpp
@@ -49,6 +49,7 @@ HWND WINAPI Test_CreateStatic(uint pid) {
    } args = { ec->chart, NO_ERROR };
 
    // create the child control
+   SetLastError(NO_ERROR);
    HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildControl, (LPARAM)&args, true);
    if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, ERR_RUNTIME_ERROR), "CreateChildControl()");
 
@@ -114,6 +115,7 @@ HWND WINAPI Test_CreateWindow(uint pid) {
    } args = { ec->chart, className, NO_ERROR };
 
    // create the child window
+   SetLastError(NO_ERROR);
    HWND hWndChild = (HWND) InvokeUiThread(local::CreateChildWindow, (LPARAM)&args, true);
    if (!hWndChild || args.error) return (HWND)!error(orElse(args.error, ERR_RUNTIME_ERROR), "CreateChildWindow()");
 

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -102,7 +102,7 @@ static DWORD WINAPI ExpanderStartThread(void* lpParam) {
    }
    PinDllToMemory();                               // otherwise we keep the DLL in memory until process termination
 
-   SetupUiIntegration();
+   IntegrateExpander();
    return NO_ERROR;
 }
 

--- a/src/lib/conversion.cpp
+++ b/src/lib/conversion.cpp
@@ -269,6 +269,13 @@ const char* WINAPI ErrorToStrA(int error) {
    #define ERROR_INSTALL_REJECTED                                      1654L
    #endif
 
+   if (error >= ERR_WIN32_ERROR) {
+      while (error >= ERR_WIN32_ERROR) {
+         error -= ERR_WIN32_ERROR;
+      }
+      error += ERR_WIN32_ERROR;
+   }
+
    switch (error) {
       case NO_ERROR                                                                       : return("NO_ERROR"                                                           );    //      0
 

--- a/src/lib/conversion.cpp
+++ b/src/lib/conversion.cpp
@@ -269,10 +269,6 @@ const char* WINAPI ErrorToStrA(int error) {
    #define ERROR_INSTALL_REJECTED                                      1654L
    #endif
 
-   while (error >= ERR_WIN32_ERROR + ERR_WIN32_ERROR) {
-      error -= ERR_WIN32_ERROR;
-   }
-
    switch (error) {
       case NO_ERROR                                                                       : return("NO_ERROR"                                                           );    //      0
 
@@ -1471,7 +1467,7 @@ const char* WINAPI ErrorToStrA(int error) {
       case ERR_WIN32_ERROR + ERROR_NOT_A_REPARSE_POINT                                    : return("win32:ERROR_NOT_A_REPARSE_POINT"                                    );    // 100000 + 4390
 
       // mapped MCI error codes
-      case ERR_MCI_ERROR                                                                  : return("MCI_NO_ERROR"                                                       );    // 100000 +                 0
+      case ERR_MCI_ERROR                                                                  : return("MCI_NO_ERROR"                                                       );    // 200000 +                 0
       case ERR_MCI_ERROR + MCIERR_INVALID_DEVICE_ID                                       : return("MCIERR_INVALID_DEVICE_ID"                                           );    // 200000 + (MCIERR_BASE +  1)
       case ERR_MCI_ERROR + MCIERR_UNRECOGNIZED_KEYWORD                                    : return("MCIERR_UNRECOGNIZED_KEYWORD"                                        );    // 200000 + (MCIERR_BASE +  3)
       case ERR_MCI_ERROR + MCIERR_UNRECOGNIZED_COMMAND                                    : return("MCIERR_UNRECOGNIZED_COMMAND"                                        );    // 200000 + (MCIERR_BASE +  5)

--- a/src/lib/conversion.cpp
+++ b/src/lib/conversion.cpp
@@ -269,11 +269,8 @@ const char* WINAPI ErrorToStrA(int error) {
    #define ERROR_INSTALL_REJECTED                                      1654L
    #endif
 
-   if (error >= ERR_WIN32_ERROR) {
-      while (error >= ERR_WIN32_ERROR) {
-         error -= ERR_WIN32_ERROR;
-      }
-      error += ERR_WIN32_ERROR;
+   while (error >= ERR_WIN32_ERROR + ERR_WIN32_ERROR) {
+      error -= ERR_WIN32_ERROR;
    }
 
    switch (error) {

--- a/src/lib/thread.cpp
+++ b/src/lib/thread.cpp
@@ -67,17 +67,17 @@ LRESULT WINAPI InvokeUiThread(UiThreadCallback func, void* args) {
    JOB job = {};
    job.func = func;
    job.args = args;
-   job.event = CreateEventW(NULL, TRUE, FALSE, NULL);
-   if (!job.event) return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "CreateEventW()");
+   job.completion = CreateEventW(NULL, TRUE, FALSE, NULL);
+   if (!job.completion) return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "CreateEventW()");
 
    if (!PostMessageW(hWndMain, WM_MT4EXPANDER(), ID_UI_CALLBACK, (LPARAM)&job)) {
-      CloseHandle(job.event);
+      CloseHandle(job.completion);
       return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "PostMessageW()");
    }
-   if (WaitForSingleObject(job.event, INFINITE) == WAIT_FAILED) {
+   if (WaitForSingleObject(job.completion, INFINITE) == WAIT_FAILED) {
       job.last_error = error(ERR_WIN32_ERROR + GetLastError(), "WaitForSingleObject()");
    }
-   CloseHandle(job.event);
+   CloseHandle(job.completion);
 
    if (job.last_error) {
       SetLastError(job.last_error);

--- a/src/lib/thread.cpp
+++ b/src/lib/thread.cpp
@@ -91,8 +91,7 @@ LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait/*=fa
       return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "PostMessageW()");
    }
 
-   DWORD retVal = WaitForSingleObject(job->done, 3000);
-   switch (retVal) {
+   switch (WaitForSingleObject(job->done, 3000)) {
       case WAIT_OBJECT_0: {
          CloseHandle(job->done);
          int     error  = job->error;
@@ -104,9 +103,12 @@ LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait/*=fa
       case WAIT_TIMEOUT:
          error(job->error = SetLastErrorEx(ERR_WIN32_ERROR + ERROR_TIMEOUT), "WaitForSingleObject()");
          break;
+
+      case WAIT_FAILED:
       default:
          error(job->error = SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "WaitForSingleObject()");
    }
+
    // deliberately orphan job and event
    return job->error ? NULL : job->result;
 }

--- a/src/lib/thread.cpp
+++ b/src/lib/thread.cpp
@@ -42,14 +42,14 @@ BOOL WINAPI IsUiThread(DWORD threadId/*= NULL*/) {
 /**
  * Executes a function in the UI thread and optionally returns the result.
  *
- * @param  UiInvokeProc func            - callback function to execute
- * @param  LPARAM       args            - callback function arguments
- * @param  bool         wait [optional] - whether to wait and return the function result (default: fire-and-forget)
+ * @param  UiThreadCallback func            - callback function to execute
+ * @param  LPARAM           args            - callback function arguments
+ * @param  bool             wait [optional] - whether to wait and return the function result (default: fire-and-forget)
  *
  * @return LRESULT - function return value if parameter `wait` is true;
  *                   NULL (0) if parameter `wait` is false or in case of errors
  */
-LRESULT WINAPI UiInvoke(UiInvokeProc func, LPARAM args, bool wait/*=false*/) {
+LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait/*=false*/) {
    if (!func) return !error(ERR_INVALID_PARAMETER, "invalid parameter func: 0x%p (not a valid pointer)", func);
 
    // execute directly if already in the UI thread

--- a/src/lib/thread.cpp
+++ b/src/lib/thread.cpp
@@ -50,7 +50,7 @@ BOOL WINAPI IsUiThread(DWORD threadId/*= NULL*/) {
  *                   NULL (0) if parameter `wait` is false or in case of errors
  */
 LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait/*=false*/) {
-   if (!func) return !error(ERR_INVALID_PARAMETER, "invalid parameter func: 0x%p (not a valid pointer)", func);
+   if (!func) return !error(SetLastErrorEx(ERR_INVALID_PARAMETER), "invalid parameter func: 0x%p (not a valid pointer)", func);
 
    // execute directly if already in the UI thread
    if (IsUiThread()) {
@@ -61,42 +61,59 @@ LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait/*=fa
    HWND hWndMain = GetTerminalMainWindow();
    if (!hWndMain) return NULL;
 
-   // dispatch function to the UI-thread
-   if (!wait) {                              // fire-and-forget
-      JOB* job = new JOB();                  // on the heap
-      job->func  = func;
-      job->args  = args;
-      job->owner = true;                     // runner will free the job
+   // prepare JOB definition
+   JOB* job = new JOB();                     // always on the heap
+   job->func  = func;
+   job->args  = args;
+   job->done  = NULL;
+   job->owner = false;
 
+   // dispatch the function call to the UI-thread
+   if (!wait) {                              // no wait, fire-and-forget, runner will free the job
+      job->owner = true;
       if (!PostMessageW(hWndMain, WM_MT4EXPANDER(), ID_UI_CALLBACK, (LPARAM)job)) {
          delete job;
-         return !error(ERR_WIN32_ERROR + GetLastError(), "PostMessageW()");
+         return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "PostMessageW()");
       }
       return NULL;
    }
 
    // wait and return the result
-   JOB job = {};
-   job.func = func;
-   job.args = args;
-   job.done = CreateEventW(NULL, TRUE, FALSE, NULL);
-   if (!job.done) return !error(ERR_WIN32_ERROR + GetLastError(), "CreateEventW()");
-
-   if (!PostMessageW(hWndMain, WM_MT4EXPANDER(), ID_UI_CALLBACK, (LPARAM)&job)) {
-      CloseHandle(job.done);
-      return !error(ERR_WIN32_ERROR + GetLastError(), "PostMessageW()");
+   job->done = CreateEventW(NULL, TRUE, FALSE, NULL);
+   if (!job->done) {
+      delete job;
+      return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "CreateEventW()");
    }
 
-   switch (WaitForSingleObject(job.done, INFINITE)) {
+   if (!PostMessageW(hWndMain, WM_MT4EXPANDER(), ID_UI_CALLBACK, (LPARAM)job)) {
+      CloseHandle(job->done);
+      delete job;
+      return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "PostMessageW()");
+   }
+
+   switch (WaitForSingleObject(job->done, 3000)) {
+      case WAIT_OBJECT_0:
+         CloseHandle(job->done);
+         delete job;
+         break;
+
+      case WAIT_TIMEOUT:
+         error(job->error = SetLastErrorEx(ERR_WIN32_ERROR + ERROR_TIMEOUT), "WaitForSingleObject() => UI thread timeout");
+         break;
+
       case WAIT_ABANDONED:
-         error(job.error = ERR_RUNTIME_ERROR, "UI thread terminated");
+         error(job->error = SetLastErrorEx(ERR_RUNTIME_ERROR), "WaitForSingleObject() => UI thread terminated");
+         CloseHandle(job->done);
+         delete job;
          break;
+
       case WAIT_FAILED:
-         error(job.error = ERR_WIN32_ERROR + GetLastError(), "WaitForSingleObject()");
+         error(job->error = SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "WaitForSingleObject()");
+         CloseHandle(job->done);
+         job->done = NULL;
          break;
    }
-   CloseHandle(job.done);
-   return job.error ? NULL : job.result;
+   return job->error ? NULL : job->result;
 }
 
 

--- a/src/lib/thread.cpp
+++ b/src/lib/thread.cpp
@@ -2,6 +2,7 @@
 #include "lib/terminal.h"
 #include "lib/thread.h"
 #include "lib/window.h"
+#include "lib/ui/integration.h"
 
 
 /**
@@ -52,24 +53,29 @@ BOOL WINAPI IsUiThread(DWORD threadId/*= NULL*/) {
 LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait/*=false*/) {
    if (!func) return !error(SetLastErrorEx(ERR_INVALID_PARAMETER), "invalid parameter func: 0x%p (not a valid pointer)", func);
 
+   SetLastError(NO_ERROR);
+
    // execute directly if already in the UI thread
    if (IsUiThread()) {
       LRESULT result = func(args);
       return wait ? result : NULL;
    }
 
+   // make sure the terminal main window is subclassed
    HWND hWndMain = GetTerminalMainWindow();
    if (!hWndMain) return NULL;
 
+   if (!GetPropW(hWndMain, PROP_WINDOW_SUBCLASSED)) {
+      return !error(SetLastErrorEx(ERR_ILLEGAL_STATE), "terminal main window not subclassed");
+   }
+
    // prepare JOB definition
-   JOB* job = new JOB();                     // always on the heap
-   job->func  = func;
-   job->args  = args;
-   job->done  = NULL;
-   job->owner = false;
+   JOB* job = new JOB();
+   job->func = func;
+   job->args = args;
 
    // dispatch the function call to the UI-thread
-   if (!wait) {                              // no wait, fire-and-forget, runner will free the job
+   if (!wait) {                              // fire-and-forget, runner will free the job
       job->owner = true;
       if (!PostMessageW(hWndMain, WM_MT4EXPANDER(), ID_UI_CALLBACK, (LPARAM)job)) {
          delete job;
@@ -78,7 +84,7 @@ LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait/*=fa
       return NULL;
    }
 
-   // wait and return the result
+   // wait to return the result
    job->done = CreateEventW(NULL, TRUE, FALSE, NULL);
    if (!job->done) {
       delete job;
@@ -91,26 +97,32 @@ LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait/*=fa
       return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "PostMessageW()");
    }
 
+   // get the result
+   int last_error = NO_ERROR;
+   LRESULT result = NULL;
+
    switch (WaitForSingleObject(job->done, 3000)) {
-      case WAIT_OBJECT_0: {
+      case WAIT_OBJECT_0: {                  // success
+         last_error = job->last_error;
+         result     = job->result;
          CloseHandle(job->done);
-         int     error  = job->error;
-         LRESULT result = job->result;
-         delete job;                         // free the job on success only
-         return error ? NULL : result;
+         delete job;
+         SetLastError(last_error);
+         return result;
       }
 
       case WAIT_TIMEOUT:
-         error(job->error = SetLastErrorEx(ERR_WIN32_ERROR + ERROR_TIMEOUT), "WaitForSingleObject()");
+         last_error = error(ERR_WIN32_ERROR + ERROR_TIMEOUT, "WaitForSingleObject()");
          break;
 
       case WAIT_FAILED:
       default:
-         error(job->error = SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "WaitForSingleObject()");
+         last_error = error(ERR_WIN32_ERROR + GetLastError(), "WaitForSingleObject()");
    }
 
    // deliberately orphan job and event
-   return job->error ? NULL : job->result;
+   SetLastError(last_error);
+   return NULL;
 }
 
 

--- a/src/lib/thread.cpp
+++ b/src/lib/thread.cpp
@@ -41,7 +41,7 @@ BOOL WINAPI IsUiThread(DWORD threadId/*= NULL*/) {
 
 
 /**
- * Executes a function in the UI thread and returns the result.
+ * Executes a callback in the UI thread and returns the result.
  *
  * @param  UiThreadCallback func - callback function to execute
  * @param  void*            args - callback function arguments

--- a/src/lib/thread.cpp
+++ b/src/lib/thread.cpp
@@ -41,88 +41,49 @@ BOOL WINAPI IsUiThread(DWORD threadId/*= NULL*/) {
 
 
 /**
- * Executes a function in the UI thread and optionally returns the result.
+ * Executes a function in the UI thread and returns the result.
  *
- * @param  UiThreadCallback func            - callback function to execute
- * @param  LPARAM           args            - callback function arguments
- * @param  bool             wait [optional] - whether to wait and return the function result (default: fire-and-forget)
+ * @param  UiThreadCallback func - callback function to execute
+ * @param  void*            args - callback function arguments
  *
- * @return LRESULT - function return value if parameter `wait` is true;
- *                   NULL (0) if parameter `wait` is false or in case of errors
+ * @return LRESULT - function return value, or NULL (0) in case of errors
  */
-LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait/*=false*/) {
+LRESULT WINAPI InvokeUiThread(UiThreadCallback func, void* args) {
    if (!func) return !error(SetLastErrorEx(ERR_INVALID_PARAMETER), "invalid parameter func: 0x%p (not a valid pointer)", func);
 
    SetLastError(NO_ERROR);
 
-   // execute directly if already in the UI thread
+   // call directly if already in the UI thread
    if (IsUiThread()) {
-      LRESULT result = func(args);
-      return wait ? result : NULL;
+      return func(args);
    }
 
-   // make sure the terminal main window is subclassed
+   // make sure the UI thread dispatcher is installed
    HWND hWndMain = GetTerminalMainWindow();
    if (!hWndMain) return NULL;
+   if (!GetPropW(hWndMain, PROP_WINDOW_SUBCLASSED)) return !error(SetLastErrorEx(ERR_ILLEGAL_STATE), "terminal main window not subclassed");
 
-   if (!GetPropW(hWndMain, PROP_WINDOW_SUBCLASSED)) {
-      return !error(SetLastErrorEx(ERR_ILLEGAL_STATE), "terminal main window not subclassed");
-   }
+   // dispatch the function call to the UI thread
+   JOB job = {};
+   job.func = func;
+   job.args = args;
+   job.event = CreateEventW(NULL, TRUE, FALSE, NULL);
+   if (!job.event) return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "CreateEventW()");
 
-   // prepare JOB definition
-   JOB* job = new JOB();
-   job->func = func;
-   job->args = args;
-
-   // dispatch the function call to the UI-thread
-   if (!wait) {                              // fire-and-forget, runner will free the job
-      job->owner = true;
-      if (!PostMessageW(hWndMain, WM_MT4EXPANDER(), ID_UI_CALLBACK, (LPARAM)job)) {
-         delete job;
-         return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "PostMessageW()");
-      }
-      return NULL;
-   }
-
-   // wait to return the result
-   job->done = CreateEventW(NULL, TRUE, FALSE, NULL);
-   if (!job->done) {
-      delete job;
-      return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "CreateEventW()");
-   }
-
-   if (!PostMessageW(hWndMain, WM_MT4EXPANDER(), ID_UI_CALLBACK, (LPARAM)job)) {
-      CloseHandle(job->done);
-      delete job;
+   if (!PostMessageW(hWndMain, WM_MT4EXPANDER(), ID_UI_CALLBACK, (LPARAM)&job)) {
+      CloseHandle(job.event);
       return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "PostMessageW()");
    }
-
-   // get the result
-   int last_error = NO_ERROR;
-   LRESULT result = NULL;
-
-   switch (WaitForSingleObject(job->done, 3000)) {
-      case WAIT_OBJECT_0: {                  // success
-         last_error = job->last_error;
-         result     = job->result;
-         CloseHandle(job->done);
-         delete job;
-         SetLastError(last_error);
-         return result;
-      }
-
-      case WAIT_TIMEOUT:
-         last_error = error(ERR_WIN32_ERROR + ERROR_TIMEOUT, "WaitForSingleObject()");
-         break;
-
-      case WAIT_FAILED:
-      default:
-         last_error = error(ERR_WIN32_ERROR + GetLastError(), "WaitForSingleObject()");
+   if (WaitForSingleObject(job.event, INFINITE) == WAIT_FAILED) {
+      job.last_error = error(ERR_WIN32_ERROR + GetLastError(), "WaitForSingleObject()");
    }
+   CloseHandle(job.event);
 
-   // deliberately orphan job and event
-   SetLastError(last_error);
-   return NULL;
+   if (job.last_error) {
+      SetLastError(job.last_error);
+      return NULL;
+   }
+   return job.result;
 }
 
 

--- a/src/lib/thread.cpp
+++ b/src/lib/thread.cpp
@@ -91,28 +91,23 @@ LRESULT WINAPI InvokeUiThread(UiThreadCallback func, LPARAM args, bool wait/*=fa
       return !error(SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "PostMessageW()");
    }
 
-   switch (WaitForSingleObject(job->done, 3000)) {
-      case WAIT_OBJECT_0:
+   DWORD retVal = WaitForSingleObject(job->done, 3000);
+   switch (retVal) {
+      case WAIT_OBJECT_0: {
          CloseHandle(job->done);
-         delete job;
-         break;
+         int     error  = job->error;
+         LRESULT result = job->result;
+         delete job;                         // free the job on success only
+         return error ? NULL : result;
+      }
 
       case WAIT_TIMEOUT:
-         error(job->error = SetLastErrorEx(ERR_WIN32_ERROR + ERROR_TIMEOUT), "WaitForSingleObject() => UI thread timeout");
+         error(job->error = SetLastErrorEx(ERR_WIN32_ERROR + ERROR_TIMEOUT), "WaitForSingleObject()");
          break;
-
-      case WAIT_ABANDONED:
-         error(job->error = SetLastErrorEx(ERR_RUNTIME_ERROR), "WaitForSingleObject() => UI thread terminated");
-         CloseHandle(job->done);
-         delete job;
-         break;
-
-      case WAIT_FAILED:
+      default:
          error(job->error = SetLastErrorEx(ERR_WIN32_ERROR + GetLastError()), "WaitForSingleObject()");
-         CloseHandle(job->done);
-         job->done = NULL;
-         break;
    }
+   // deliberately orphan job and event
    return job->error ? NULL : job->result;
 }
 

--- a/src/lib/ui/integration.cpp
+++ b/src/lib/ui/integration.cpp
@@ -8,11 +8,9 @@
 
 #include <commctrl.h>
 
-#define MAIN_WINDOW_SUBCLASS_ID     1                 // subclass identifier for the main window
+#define MAIN_WINDOW_SUBCLASS_ID     1                 // subclass identifier for the terminal main window
 #define CHART_WINDOW_SUBCLASS_ID    2                 // subclass identifier for chart windows
-#define CHART_FRAME_SUBCLASS_ID     3                 // subclass identifier for chart frames (painting area)
-
-#define PROP_WINDOW_SUBCLASSED      L"rsfMT4Expander.subclassed"
+#define CHART_FRAME_SUBCLASS_ID     3                 // subclass identifier for chart frames (painting areas)
 
 static HHOOK hUiThreadHook    = NULL;                 // hook handles
 static HHOOK hWindowEventHook = NULL;
@@ -29,9 +27,9 @@ BOOL WINAPI IntegrateExpander() {
 
    // if not in the UI thread
    if (!IsUiThread()) {
-      static BOOL done = FALSE;
+      static bool done = false;
       if (!done) {                                    // no full synchronization needed
-         done = TRUE;
+         done = true;
          if (!CustomizeTerminal()) return FALSE;      // perform configured modifications
          if (!HookUiThread())      return FALSE;      // continue in the UI thread
       }
@@ -39,9 +37,9 @@ BOOL WINAPI IntegrateExpander() {
    }
 
    // if in the UI thread
-   static BOOL done = FALSE;
+   static bool done = false;
    if (!done) {                                       // fully synchronized
-      done = TRUE;
+      done = true;
       if (!SubclassMainWindow())      return FALSE;
       if (!SubclassChartWindows())    return FALSE;
       if (!RegisterWindowEventHook()) return FALSE;   // in the UI thread and after MT4 installed its own blocking hook
@@ -168,7 +166,7 @@ static BOOL WINAPI SubclassMainWindow() {
    if (!hWnd) return FALSE;
 
    if (GetPropW(hWnd, PROP_WINDOW_SUBCLASSED)) {
-      warn("main window %p already subclassed", hWnd);      // accepted but an issue: we want to know
+      warn("terminal main window %p already subclassed", hWnd);
       return TRUE;
    }
    if (!SetWindowSubclass(hWnd, MainWindowSubclassProc, MAIN_WINDOW_SUBCLASS_ID, 0)) {
@@ -177,7 +175,7 @@ static BOOL WINAPI SubclassMainWindow() {
    SetPropW(hWnd, PROP_WINDOW_SUBCLASSED, (HANDLE)1);
 
    static DWORD debugFeatures = GetDebugFeatures();
-   if (debugFeatures & DEBUG_FEATURE_SUBCLASS) debug("main window %p subclassed", hWnd);
+   if (debugFeatures & DEBUG_FEATURE_SUBCLASS) debug("terminal main window %p subclassed", hWnd);
    return TRUE;
 }
 

--- a/src/lib/ui/integration.cpp
+++ b/src/lib/ui/integration.cpp
@@ -19,21 +19,21 @@ static HHOOK hWindowEventHook = NULL;
 
 
 /**
- * Setup UI integration of the Expander. Called two times: once from a non-UI thread, once from the UI thread.
- * The first call is always from a non-UI thread (worker in DLL loader).
+ * Integrate the Expander in the terminal process. Called two times: first from a non-UI thread (worker in DLL loader),
+ * then from the UI thread.
  *
  * @return BOOL - success status
  */
-BOOL WINAPI SetupUiIntegration() {
-   // Some integration tasks must run in the UI thread. Some must not run there. Some may run anywhere.
+BOOL WINAPI IntegrateExpander() {
+   // Some integration tasks MUST run in the UI thread. Some MUST NOT not run there. Some may run anywhere.
 
-   // if in a non-UI thread
+   // if not in the UI thread
    if (!IsUiThread()) {
       static BOOL done = FALSE;
       if (!done) {                                    // no full synchronization needed
          done = TRUE;
          if (!CustomizeTerminal()) return FALSE;      // perform configured modifications
-         if (!NotifyUiThread())    return FALSE;      // continue in the UI thread
+         if (!HookUiThread())      return FALSE;      // continue in the UI thread
       }
       return TRUE;
    }
@@ -119,22 +119,22 @@ static LRESULT CALLBACK WindowEventHook(int type, WPARAM wParam, LPARAM lParam) 
  *
  * @return BOOL - success status
  */
-static BOOL WINAPI NotifyUiThread() {
-   // register a hook for sent messages
-   hUiThreadHook = SetWindowsHookEx(WH_CALLWNDPROC, UiThreadHook, NULL, GetUiThreadId());
-   if (!hUiThreadHook) return !error(ERR_WIN32_ERROR + GetLastError(), "SetWindowsHookEx(UiThreadHook)");
+static BOOL WINAPI HookUiThread() {
+   // register a hook for messages sent to any window owned by the UI thread
+   hUiThreadHook = SetWindowsHookEx(WH_CALLWNDPROC, UiThreadHookProc, NULL, GetUiThreadId());
+   if (!hUiThreadHook) return !error(ERR_WIN32_ERROR + GetLastError(), "SetWindowsHookEx(UiThreadHookProc)");
 
    // trigger the UI thread
    SetLastError(ERROR_SUCCESS);
    if (!SendMessageTimeout(GetTerminalMainWindow(), WM_NULL, 0, 0, SMTO_ABORTIFHUNG | SMTO_NOTIMEOUTIFNOTHUNG, 3000, NULL)) {
-      warn(ERR_WIN32_ERROR + GetLastError(), "SendMessageTimeout()");  // don't fail, as the hook is OK
+      warn(ERR_WIN32_ERROR + GetLastError(), "SendMessageTimeout()");  // may fail if the UI thread doesn't process the message in time
    }
    return TRUE;
 }
 
 
 /**
- * Hook procedure (listener) for messages sent to the terminal main window (UI thread). Continues Expander integration and
+ * Hook procedure for messages sent to any window owned by the UI thread. Continues Expander integration and
  * removes itself.
  *
  * @param  int    code   - below 0 (zero) if the hook should skip the message
@@ -143,16 +143,16 @@ static BOOL WINAPI NotifyUiThread() {
  *
  * @return LRESULT - return value of CallNextHookEx()
  */
-static LRESULT CALLBACK UiThreadHook(int code, WPARAM wParam, LPARAM lParam) {
+static LRESULT CALLBACK UiThreadHookProc(int code, WPARAM wParam, LPARAM lParam) {
    if (code >= 0) {
       if (hUiThreadHook) {
          HHOOK hHook = hUiThreadHook;
          hUiThreadHook = NULL;
-         if (!UnhookWindowsHookEx(hHook)) error(ERR_WIN32_ERROR + GetLastError(), "UnhookWindowsHookEx(hHook=0x%p)", hHook);
-         SetupUiIntegration();                                    // continue Expander integration
+         if (!UnhookWindowsHookEx(hHook)) error(ERR_WIN32_ERROR + GetLastError(), "UnhookWindowsHookEx(hUiThreadHook=0x%p)", hHook);
+         IntegrateExpander();                                     // recursive call to continue integration in the UI thread
       }
    }
-   return CallNextHookEx(hUiThreadHook, code, wParam, lParam);    // will be NULL after the hook was removed
+   return CallNextHookEx(hUiThreadHook, code, wParam, lParam);    // hUiThreadHook will be NULL after the hook was removed
 }
 
 


### PR DESCRIPTION
Issue: #52

Additional protection against the hanging scenario:
- before dispatcher invokation a check is made whether the dispatcher was successfully installed

The API has been simplified. An invokation of the dispatcher always waits for the result (return value).

@codex review