### PR TITLE
Update config file names and functions

### DIFF
--- a/header/lib/configuration.h
+++ b/header/lib/configuration.h
@@ -1,10 +1,10 @@
 #pragma once
 #include "expander.h"
 
-const char* WINAPI GetGlobalConfigPathA();
+const char* WINAPI GetUserConfigPathA();
 const char* WINAPI GetTerminalConfigPathA();
 
-BOOL        WINAPI IsGlobalConfigKeyA(const char* section, const char* key);
+BOOL        WINAPI IsUserConfigKeyA(const char* section, const char* key);
 BOOL        WINAPI IsTerminalConfigKeyA(const char* section, const char* key);
 
 BOOL        WINAPI IsIniKeyA(const char* fileName, const char* section, const char* key);

--- a/header/lib/configuration.h
+++ b/header/lib/configuration.h
@@ -5,6 +5,7 @@ const char*  WINAPI GetUserConfigPathA();
 const wchar* WINAPI GetUserConfigPathW();
 
 const char*  WINAPI GetTerminalConfigPathA();
+const wchar* WINAPI GetTerminalConfigPathW();
 
 BOOL         WINAPI IsUserConfigKeyA(const char* section, const char* key);
 BOOL         WINAPI IsTerminalConfigKeyA(const char* section, const char* key);

--- a/header/lib/configuration.h
+++ b/header/lib/configuration.h
@@ -1,21 +1,23 @@
 #pragma once
 #include "expander.h"
 
-const char* WINAPI GetUserConfigPathA();
-const char* WINAPI GetTerminalConfigPathA();
+const char*  WINAPI GetUserConfigPathA();
+const wchar* WINAPI GetUserConfigPathW();
 
-BOOL        WINAPI IsUserConfigKeyA(const char* section, const char* key);
-BOOL        WINAPI IsTerminalConfigKeyA(const char* section, const char* key);
+const char*  WINAPI GetTerminalConfigPathA();
 
-BOOL        WINAPI IsIniKeyA(const char* fileName, const char* section, const char* key);
-BOOL        WINAPI DeleteIniKeyA(const char* fileName, const char* section, const char* key);
+BOOL         WINAPI IsUserConfigKeyA(const char* section, const char* key);
+BOOL         WINAPI IsTerminalConfigKeyA(const char* section, const char* key);
 
-BOOL        WINAPI IsIniSectionA(const char* fileName, const char* section);
-BOOL        WINAPI DeleteIniSectionA(const char* fileName, const char* section);
-BOOL        WINAPI EmptyIniSectionA(const char* fileName, const char* section);
+BOOL         WINAPI IsIniKeyA(const char* fileName, const char* section, const char* key);
+BOOL         WINAPI DeleteIniKeyA(const char* fileName, const char* section, const char* key);
 
-uint        WINAPI GetIniKeysA(const char* fileName, const char* section, char* buffer, uint bufferSize);
-uint        WINAPI GetIniSectionsA(const char* fileName, char* buffer, uint bufferSize);
+BOOL         WINAPI IsIniSectionA(const char* fileName, const char* section);
+BOOL         WINAPI DeleteIniSectionA(const char* fileName, const char* section);
+BOOL         WINAPI EmptyIniSectionA(const char* fileName, const char* section);
 
-char*       WINAPI GetIniStringA(const char* fileName, const char* section, const char* key, const char* defaultValue = "");
-char*       WINAPI GetIniStringRawA(const char* fileName, const char* section, const char* key, const char* defaultValue = "");
+uint         WINAPI GetIniKeysA(const char* fileName, const char* section, char* buffer, uint bufferSize);
+uint         WINAPI GetIniSectionsA(const char* fileName, char* buffer, uint bufferSize);
+
+char*        WINAPI GetIniStringA(const char* fileName, const char* section, const char* key, const char* defaultValue = "");
+char*        WINAPI GetIniStringRawA(const char* fileName, const char* section, const char* key, const char* defaultValue = "");

--- a/header/lib/file.h
+++ b/header/lib/file.h
@@ -30,12 +30,15 @@ struct REPARSE_DATA_BUFFER {
 #define SYMLINK_FLAG_RELATIVE 1
 
 int    WINAPI CreateDirectoryA(const char* path, DWORD flags);
+int    WINAPI CreateDirectoryW(const wchar* path, DWORD flags);
 char*  WINAPI GetFinalPathNameA(const char* name);
 char*  WINAPI GetReparsePointTargetA(const char* name);
 BOOL   WINAPI IsDirectoryA(const char* path, DWORD mode);
+BOOL   WINAPI IsDirectoryW(const wchar* path, DWORD mode);
 BOOL   WINAPI IsFileA(const char* path, DWORD mode);
 BOOL   WINAPI IsFileW(const wchar* path, DWORD mode);
 BOOL   WINAPI IsFileOrDirectoryA(const char* name);
+BOOL   WINAPI IsFileOrDirectoryW(const wchar* name);
 BOOL   WINAPI IsJunctionA(const char* name);
 BOOL   WINAPI IsSymlinkA(const char* name);
 

--- a/header/lib/string.h
+++ b/header/lib/string.h
@@ -14,8 +14,8 @@
 #define strtoint     atoi              // convert a C string to an integer
 #define wstrtoint    _wtoi             // convert a UTF-16 string to an integer
 
-#define wstrcmp      wcscmp            // case-sensitive comparison of two UTF-16 strings
-#define wstricmp     wcsicmp           // case-insensitive comparison of two UTF-16 strings
+#define wstrcmp      wcscmp            // case sensitive comparison of two UTF-16 strings
+#define wstricmp     wcsicmp           // case insensitive comparison of two UTF-16 strings
 
 
 namespace rsf {

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -94,45 +94,13 @@ const char* WINAPI GetTerminalConfigPathA() {
    static char* configPath;
 
    if (!configPath) {
-      const char* dataPath = GetTerminalDataPathA();
-      if (!dataPath) return NULL;
+      const wchar* wpath = GetTerminalConfigPathW();
+      if (!wpath) return NULL;
 
-      string iniFile = string(dataPath).append("\\rsf-terminal-config.ini");
-      char* tmp = sdup(iniFile.c_str());
+      char* tmp = utf16ToAnsi(wpath);
       if (!configPath) configPath = tmp;
-      else             free(tmp);                                          // another thread may have been faster
-
-      // make sure the config directory exists (applies to non-portable mode only)
-      if (!IsDirectoryA(dataPath, MODE_SYSTEM)) {
-         int error = CreateDirectoryA(dataPath, MODE_SYSTEM|MODE_MKPARENT);
-         if (error) {
-            warn(error, "cannot create directory \"%s\"", dataPath);
-            return configPath;
-         }
-
-         // if in non-portable mode (terminalPath != dataPath): make sure file "origin.txt" exists
-         const char* terminalPath = GetTerminalPathA();
-         if (!StrCompare(terminalPath, dataPath)) {
-            string originFile = string(dataPath).append("\\origin.txt");   // store file "origin.txt"
-            std::ofstream file(originFile.c_str());
-            if (file.is_open()) {
-               file << terminalPath << NL;
-               file.close();
-            }
-            else {
-               warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%s\" (%s)", originFile.c_str(), strerror(errno));
-            }
-         }
-      }
-
-      // make sure the config file exists
-      if (!IsFileA(configPath, MODE_SYSTEM)) {
-         std::ofstream file(configPath);
-         if (file.is_open()) file.close();
-         else                warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%s\" (%s)", configPath, strerror(errno));
-      }
+      else             free(tmp);                                             // another thread may have been faster
    }
-
    return configPath;
    #pragma EXPANDER_EXPORT
 }

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -171,11 +171,13 @@ const wchar* WINAPI GetTerminalConfigPathW() {
                   static int done = warn(ERR_WIN32_ERROR + error, "cannot create file \"%S\"", originFile.c_str());
                }
             }
-            else if (const wchar* terminalPath = GetTerminalPathW()) {
-               string content = utf16ToAnsi(wstring(terminalPath)).append(CRLF);
-               DWORD bytesWritten;
-               if (!WriteFile(hFile, content.c_str(), (DWORD)content.length(), &bytesWritten, NULL)) {
-                  static int done = warn(ERR_WIN32_ERROR + GetLastError(), "cannot write to file \"%S\"", originFile.c_str());
+            else {
+               if (const wchar* terminalPath = GetTerminalPathW()) {
+                  string content = utf16ToAnsi(wstring(terminalPath)).append(CRLF);
+                  DWORD bytesWritten;
+                  if (!WriteFile(hFile, content.c_str(), (DWORD)content.length(), &bytesWritten, NULL)) {
+                     static int done = warn(ERR_WIN32_ERROR + GetLastError(), "cannot write to file \"%S\"", originFile.c_str());
+                  }
                }
                CloseHandle(hFile);
             }

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -22,29 +22,13 @@ const char* WINAPI GetUserConfigPathA() {
    static char* configPath;
 
    if (!configPath) {
-      const char* commonDataPath = GetTerminalCommonDataPathA();
-      if (!commonDataPath) return NULL;
+      const wchar* wpath = GetUserConfigPathW();
+      if (!wpath) return NULL;
 
-      string filename = string(commonDataPath).append("\\rsf-user-config.ini");
-      char* tmp = sdup(filename.c_str());
+      char* tmp = utf16ToAnsi(wpath);
       if (!configPath) configPath = tmp;
       else             free(tmp);                  // another thread may have been faster
-
-      if (!IsFileA(configPath, MODE_SYSTEM)) {
-         // make sure the directory exists
-         int error = CreateDirectoryA(commonDataPath, MODE_SYSTEM|MODE_MKPARENT);
-         if (error) {
-            warn(error, "cannot create directory \"%s\" (%s)", commonDataPath, strerror(errno));
-         }
-         else {
-            // make sure the file exists
-            std::ofstream file(configPath);
-            if (file.is_open()) file.close();
-            else                warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%s\" (%s)", configPath, strerror(errno));
-         }
-      }
    }
-
    return configPath;
    #pragma EXPANDER_EXPORT
 }

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -99,7 +99,7 @@ const char* WINAPI GetTerminalConfigPathA() {
 
       char* tmp = utf16ToAnsi(wpath);
       if (!configPath) configPath = tmp;
-      else             free(tmp);                                             // another thread may have been faster
+      else             free(tmp);                  // another thread may have been faster
    }
    return configPath;
    #pragma EXPANDER_EXPORT
@@ -127,7 +127,7 @@ const wchar* WINAPI GetTerminalConfigPathW() {
       wstring iniFile = wstring(dataPath).append(L"\\rsf-terminal-config.ini");
       wchar* tmp = wsdup(iniFile.c_str());
       if (!configPath) configPath = tmp;
-      else             free(tmp);                                             // another thread may have been faster
+      else             free(tmp);                                    // another thread may have been faster
 
       // make sure the config directory exists (applies to non-portable mode only)
       if (!IsDirectoryW(dataPath, MODE_SYSTEM)) {
@@ -140,30 +140,34 @@ const wchar* WINAPI GetTerminalConfigPathW() {
          // if in non-portable mode (terminalPath != dataPath): make sure file "origin.txt" exists
          const wchar* terminalPath = GetTerminalPathW();
          if (!StrCompare(terminalPath, dataPath)) {
-            wstring originFile = wstring(dataPath).append(L"\\origin.txt");   // store file "origin.txt"
+            wstring originFile = wstring(dataPath).append(L"\\origin.txt");
 
-            HANDLE hFile = CreateFileW(originFile.c_str(), GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-            if (hFile == INVALID_HANDLE_VALUE) {
-               if (GetLastError() != ERROR_SHARING_VIOLATION) {               // ignore if open elsewhere
-                  warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", originFile.c_str());
+            if (!IsFileW(originFile.c_str(), MODE_SYSTEM)) {
+               HANDLE hFile = CreateFileW(originFile.c_str(), GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+               if (hFile == INVALID_HANDLE_VALUE) {
+                  if (GetLastError() != ERROR_SHARING_VIOLATION) {   // ignore if open elsewhere
+                     warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", originFile.c_str());
+                  }
                }
-            }
-            else {
-               string content = utf16ToAnsi(wstring(terminalPath)) + CRLF;
-               DWORD bytesWritten;
-               if (!WriteFile(hFile, content.c_str(), (DWORD)content.length(), &bytesWritten, NULL)) {
-                  warn(ERR_WIN32_ERROR + GetLastError(), "cannot write to file \"%S\"", originFile.c_str());
+               else {
+                  string content = utf16ToAnsi(wstring(terminalPath)).append(CRLF);
+                  DWORD bytesWritten;
+                  if (!WriteFile(hFile, content.c_str(), (DWORD)content.length(), &bytesWritten, NULL)) {
+                     warn(ERR_WIN32_ERROR + GetLastError(), "cannot write to file \"%S\"", originFile.c_str());
+                  }
+                  CloseHandle(hFile);
                }
-               CloseHandle(hFile);
             }
          }
       }
 
-      // make sure the config file exists (OPEN_ALWAYS: create if missing)
-      if (!IsFileW(configPath, MODE_SYSTEM)) {
+      // make sure the config file exists
+      if (!IsFileW(configPath, MODE_SYSTEM)) {                       // create if missing
          HANDLE hFile = CreateFileW(configPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
          if (hFile == INVALID_HANDLE_VALUE) {
-            warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", configPath);
+            if (GetLastError() != ERROR_SHARING_VIOLATION) {         // ignore if open elsewhere
+               warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", configPath);
+            }
          }
          else {
             CloseHandle(hFile);

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -57,7 +57,7 @@ const wchar* WINAPI GetUserConfigPathW() {
       else             free(tmp);                  // another thread may have been faster
 
       if (!IsFileW(configPath, MODE_SYSTEM)) {
-         // make sure the directory exists
+         // make sure the config directory exists
          int error = CreateDirectoryW(commonDataPath, MODE_SYSTEM|MODE_MKPARENT);
          if (error) {
             warn(error, "cannot create directory \"%S\"", commonDataPath);
@@ -106,7 +106,7 @@ const char* WINAPI GetTerminalConfigPathA() {
       if (!IsDirectoryA(dataPath, MODE_SYSTEM)) {
          int error = CreateDirectoryA(dataPath, MODE_SYSTEM|MODE_MKPARENT);
          if (error) {
-            warn(ERR_WIN32_ERROR + error, "cannot create directory \"%s\" (%s)", dataPath, strerror(errno));
+            warn(error, "cannot create directory \"%s\"", dataPath);
             return configPath;
          }
 
@@ -130,6 +130,76 @@ const char* WINAPI GetTerminalConfigPathA() {
          std::ofstream file(configPath);
          if (file.is_open()) file.close();
          else                warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%s\" (%s)", configPath, strerror(errno));
+      }
+   }
+
+   return configPath;
+   #pragma EXPANDER_EXPORT
+}
+
+
+/**
+ * Returns the full name of the terminal-specific configuration file.
+ *
+ * - This configuration file is used by the currently active terminal only.
+ * - The file is named "rsf-terminal-config.ini" and is located in the terminal-specific data folder. If the terminal runs in
+ *   "portable mode", the data folder is the terminal's installation folder.
+ * - If the file does not exist an attempt is made to create it.
+ *
+ * @return char* - file name or a NULL pointer in case of errors,
+ *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\{installation-id}\rsf-terminal-config.ini"
+ */
+const wchar* WINAPI GetTerminalConfigPathW() {
+   static wchar* configPath;
+
+   if (!configPath) {
+      const wchar* dataPath = GetTerminalDataPathW();
+      if (!dataPath) return NULL;
+
+      wstring iniFile = wstring(dataPath).append(L"\\rsf-terminal-config.ini");
+      wchar* tmp = wsdup(iniFile.c_str());
+      if (!configPath) configPath = tmp;
+      else             free(tmp);                                             // another thread may have been faster
+
+      // make sure the config directory exists (applies to non-portable mode only)
+      if (!IsDirectoryW(dataPath, MODE_SYSTEM)) {
+         int error = CreateDirectoryW(dataPath, MODE_SYSTEM|MODE_MKPARENT);
+         if (error) {
+            warn(error, "cannot create directory \"%S\"", dataPath);
+            return configPath;
+         }
+
+         // if in non-portable mode (terminalPath != dataPath): make sure file "origin.txt" exists
+         const wchar* terminalPath = GetTerminalPathW();
+         if (!StrCompare(terminalPath, dataPath)) {
+            wstring originFile = wstring(dataPath).append(L"\\origin.txt");   // store file "origin.txt"
+
+            HANDLE hFile = CreateFileW(originFile.c_str(), GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+            if (hFile == INVALID_HANDLE_VALUE) {
+               if (GetLastError() != ERROR_SHARING_VIOLATION) {               // ignore if open elsewhere
+                  warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", originFile.c_str());
+               }
+            }
+            else {
+               string content = utf16ToAnsi(wstring(terminalPath)) + CRLF;
+               DWORD bytesWritten;
+               if (!WriteFile(hFile, content.c_str(), (DWORD)content.length(), &bytesWritten, NULL)) {
+                  warn(ERR_WIN32_ERROR + GetLastError(), "cannot write to file \"%S\"", originFile.c_str());
+               }
+               CloseHandle(hFile);
+            }
+         }
+      }
+
+      // make sure the config file exists (OPEN_ALWAYS: create if missing)
+      if (!IsFileW(configPath, MODE_SYSTEM)) {
+         HANDLE hFile = CreateFileW(configPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+         if (hFile == INVALID_HANDLE_VALUE) {
+            warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", configPath);
+         }
+         else {
+            CloseHandle(hFile);
+         }
       }
    }
 

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -68,17 +68,23 @@ const wchar* WINAPI GetUserConfigPathW() {
       // rename an existing legacy config file
       else {
          wstring legacyName = wstring(commonDataPath).append(L"\\global-config.ini");
-         if (IsFileW(legacyName.c_str(), MODE_SYSTEM)) {          // check legacy file for existence and rename it
+
+         BOOL isLegacyFile = IsFileW(legacyName.c_str(), MODE_SYSTEM);
+         if (isLegacyFile) {                                      // check legacy file for existence and rename it
             if (MoveFileExW(legacyName.c_str(), fileName.c_str(), MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH|MOVEFILE_FAIL_IF_NOT_TRACKABLE)) {
                info("renamed \"global-config.ini\" to \"rsf-user-config.ini\"");
                result = wsdup(fileName.c_str());
             }
             else {
-               static int done = warn(ERR_WIN32_ERROR + GetLastError(), "cannot rename \"%S\" to \"%S\"", legacyName.c_str(), fileName.c_str());
-               result = wsdup(legacyName.c_str());                // keep using the old "global-config.ini"
+               DWORD error = GetLastError();
+               static int done = warn(ERR_WIN32_ERROR + error, "cannot rename \"%S\" to \"%S\"", legacyName.c_str(), fileName.c_str());
+               if (isLegacyFile = (error != ERROR_FILE_NOT_FOUND)) {
+                  result = wsdup(legacyName.c_str());             // keep using the old "global-config.ini"
+               }
             }
          }
-         else {                                                   // create "rsf-user-config.ini"
+
+         if (!isLegacyFile) {                                     // create "rsf-user-config.ini"
             HANDLE hFile = CreateFileW(fileName.c_str(), 0, FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
             if (hFile == INVALID_HANDLE_VALUE) {
                if (GetLastError() != ERROR_SHARING_VIOLATION) {   // ignore if open elsewhere
@@ -188,19 +194,23 @@ const wchar* WINAPI GetTerminalConfigPathW() {
       else {
          // rename an existing legacy config file
          wstring legacyName = wstring(dataPath).append(L"\\terminal-config.ini");
-         if (IsFileW(legacyName.c_str(), MODE_SYSTEM)) {          // check legacy file for existence and rename it
+
+         BOOL isLegacyFile = IsFileW(legacyName.c_str(), MODE_SYSTEM);
+         if (isLegacyFile) {                                      // check legacy file for existence and rename it
             if (MoveFileExW(legacyName.c_str(), fileName.c_str(), MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH|MOVEFILE_FAIL_IF_NOT_TRACKABLE)) {
                info("renamed \"terminal-config.ini\" to \"rsf-terminal-config.ini\"");
                result = wsdup(fileName.c_str());
             }
             else {
-               static int done = warn(ERR_WIN32_ERROR + GetLastError(), "cannot rename \"%S\" to \"%S\"", legacyName.c_str(), fileName.c_str());
-               result = wsdup(legacyName.c_str());                // keep using the old "terminal-config.ini"
+               DWORD error = GetLastError();
+               static int done = warn(ERR_WIN32_ERROR + error, "cannot rename \"%S\" to \"%S\"", legacyName.c_str(), fileName.c_str());
+               if (isLegacyFile = (error != ERROR_FILE_NOT_FOUND)) {
+                  result = wsdup(legacyName.c_str());             // keep using the old "terminal-config.ini"
+               }
             }
          }
 
-         // create "rsf-terminal-config.ini"
-         else {
+         if (!isLegacyFile) {                                     // create "rsf-terminal-config.ini"
             HANDLE hFile = CreateFileW(fileName.c_str(), 0, FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
             if (hFile == INVALID_HANDLE_VALUE) {
                if (GetLastError() != ERROR_SHARING_VIOLATION) {   // ignore if open elsewhere

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -49,30 +49,47 @@ const wchar* WINAPI GetUserConfigPathW() {
       const wchar* commonDataPath = GetTerminalCommonDataPathW();
       if (!commonDataPath) return NULL;
 
-      wstring filename = wstring(commonDataPath).append(L"\\rsf-user-config.ini");
-      wchar* tmp = wsdup(filename.c_str());
-      if (!configPath) configPath = tmp;
-      else             free(tmp);                                 // another thread may have been faster
+      // make sure the directory exists
+      int error = CreateDirectoryW(commonDataPath, MODE_SYSTEM|MODE_MKPARENT);
+      if (error) {
+         static int done = warn(error, "cannot create directory \"%S\"", commonDataPath);
+         return NULL;
+      }
 
-      if (!IsFileW(configPath, MODE_SYSTEM)) {
-         // make sure the config directory exists
-         int error = CreateDirectoryW(commonDataPath, MODE_SYSTEM|MODE_MKPARENT);
-         if (error) {
-            warn(error, "cannot create directory \"%S\"", commonDataPath);
+      // make sure the config file exists, and migrate an existing legacy config file
+      wstring fileName = wstring(commonDataPath).append(L"\\rsf-user-config.ini");
+      wchar* result = NULL;
+
+      if (IsFileW(fileName.c_str(), MODE_SYSTEM)) {               // check "rsf-user-config.ini" for existence
+         result = wsdup(fileName.c_str());
+      }
+      else {                                                      // check "global-config.ini" for existence
+         wstring legacyName = wstring(commonDataPath).append(L"\\global-config.ini");
+         if (IsFileW(legacyName.c_str(), MODE_SYSTEM)) {          // rename "global-config.ini" to "rsf-user-config.ini"
+            if (!MoveFileExW(legacyName.c_str(), fileName.c_str(), MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH|MOVEFILE_FAIL_IF_NOT_TRACKABLE)) {
+               static int done = warn(ERR_WIN32_ERROR + GetLastError(), "cannot rename \"%S\" to \"%S\"", legacyName.c_str(), fileName.c_str());
+               result = wsdup(legacyName.c_str());                // keep using old "global-config.ini"
+            }
+            else {
+               result = wsdup(fileName.c_str());
+            }
          }
-         else {
-            // make sure the config file exists
-            HANDLE hFile = CreateFileW(configPath, 0, FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+         else {                                                   // create "rsf-user-config.ini"
+            HANDLE hFile = CreateFileW(fileName.c_str(), 0, FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
             if (hFile == INVALID_HANDLE_VALUE) {
                if (GetLastError() != ERROR_SHARING_VIOLATION) {   // ignore if open elsewhere
-                  warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", configPath);
+                  static int done = warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", fileName.c_str());
                }
             }
             else {
                CloseHandle(hFile);
             }
+            result = wsdup(fileName.c_str());
          }
       }
+
+      if (!configPath) configPath = result;
+      else             free(result);                              // another thread may have been faster
    }
    return configPath;
    #pragma EXPANDER_EXPORT

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -38,6 +38,7 @@ const char* WINAPI GetUserConfigPathA() {
  * - This configuration file is used by all terminals installed by the user.
  * - The file is named "rsf-user-config.ini" and is located in the terminal's common data folder.
  * - If the file does not exist an attempt is made to create it.
+ * - An existing legacy config file "global-config.ini" is renamed to the new name.
  *
  * @return char* - file name or a NULL pointer in case of errors,
  *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\Common\rsf-user-config.ini"
@@ -49,25 +50,27 @@ const wchar* WINAPI GetUserConfigPathW() {
       const wchar* commonDataPath = GetTerminalCommonDataPathW();
       if (!commonDataPath) return NULL;
 
+      wstring fileName = wstring(commonDataPath).append(L"\\rsf-user-config.ini");
+      wchar* result = NULL;
+
       // make sure the directory exists
       int error = CreateDirectoryW(commonDataPath, MODE_SYSTEM|MODE_MKPARENT);
       if (error) {
          static int done = warn(error, "cannot create directory \"%S\"", commonDataPath);
-         return NULL;
-      }
-
-      // make sure the config file exists, and migrate an existing legacy config file
-      wstring fileName = wstring(commonDataPath).append(L"\\rsf-user-config.ini");
-      wchar* result = NULL;
-
-      if (IsFileW(fileName.c_str(), MODE_SYSTEM)) {               // check "rsf-user-config.ini" for existence
          result = wsdup(fileName.c_str());
       }
-      else {                                                      // check "global-config.ini" for existence
+
+      // check "rsf-user-config.ini" for existence
+      else if (IsFileW(fileName.c_str(), MODE_SYSTEM)) {
+         result = wsdup(fileName.c_str());
+      }
+
+      // rename an existing legacy config file
+      else {
          wstring legacyName = wstring(commonDataPath).append(L"\\global-config.ini");
-         if (IsFileW(legacyName.c_str(), MODE_SYSTEM)) {          // rename "global-config.ini" to "rsf-user-config.ini"
+         if (IsFileW(legacyName.c_str(), MODE_SYSTEM)) {          // check legacy file for existence and rename it
             if (MoveFileExW(legacyName.c_str(), fileName.c_str(), MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH|MOVEFILE_FAIL_IF_NOT_TRACKABLE)) {
-               info("renamed \"%S\" to \"%S\"", legacyName.c_str(), fileName.c_str());
+               info("renamed \"global-config.ini\" to \"rsf-user-config.ini\"");
                result = wsdup(fileName.c_str());
             }
             else {
@@ -129,8 +132,9 @@ const char* WINAPI GetTerminalConfigPathA() {
  *
  * - This configuration file is used by the currently active terminal only.
  * - The file is named "rsf-terminal-config.ini" and is located in the terminal-specific data folder. If the terminal runs in
- *   "portable mode", the data folder is the terminal's installation folder.
+ *   "portable mode", then the data folder is the terminal's installation folder.
  * - If the file does not exist an attempt is made to create it.
+ * - An existing legacy config file "terminal-config.ini" is renamed to the new name.
  *
  * @return char* - file name or a NULL pointer in case of errors,
  *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\{installation-id}\rsf-terminal-config.ini"
@@ -142,55 +146,74 @@ const wchar* WINAPI GetTerminalConfigPathW() {
       const wchar* dataPath = GetTerminalDataPathW();
       if (!dataPath) return NULL;
 
-      wstring iniFile = wstring(dataPath).append(L"\\rsf-terminal-config.ini");
-      wchar* tmp = wsdup(iniFile.c_str());
-      if (!configPath) configPath = tmp;
-      else             free(tmp);                                    // another thread may have been faster
+      wstring fileName = wstring(dataPath).append(L"\\rsf-terminal-config.ini");
+      wchar* result = NULL;
 
-      // make sure the config directory exists (applies to non-portable mode only)
+      // make sure the directory exists
       if (!IsDirectoryW(dataPath, MODE_SYSTEM)) {
          int error = CreateDirectoryW(dataPath, MODE_SYSTEM|MODE_MKPARENT);
          if (error) {
-            warn(error, "cannot create directory \"%S\"", dataPath);
-            return configPath;
+            static int done = warn(error, "cannot create directory \"%S\"", dataPath);
          }
-
-         // if in non-portable mode (terminalPath != dataPath): make sure file "origin.txt" exists
-         const wchar* terminalPath = GetTerminalPathW();
-         if (!StrCompare(terminalPath, dataPath)) {
+         else if (!IsPortableMode()) {                            // in non-portable mode we have to create file "origin.txt"
             wstring originFile = wstring(dataPath).append(L"\\origin.txt");
 
             HANDLE hFile = CreateFileW(originFile.c_str(), GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_DELETE, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
             if (hFile == INVALID_HANDLE_VALUE) {
-               DWORD error = GetLastError();                         // ignore if open elsewhere
+               DWORD error = GetLastError();                      // ignore if open elsewhere
                if (error != ERROR_FILE_EXISTS && error != ERROR_SHARING_VIOLATION) {
-                  warn(ERR_WIN32_ERROR + error, "cannot create file \"%S\"", originFile.c_str());
+                  static int done = warn(ERR_WIN32_ERROR + error, "cannot create file \"%S\"", originFile.c_str());
                }
             }
-            else {
+            else if (const wchar* terminalPath = GetTerminalPathW()) {
                string content = utf16ToAnsi(wstring(terminalPath)).append(CRLF);
                DWORD bytesWritten;
                if (!WriteFile(hFile, content.c_str(), (DWORD)content.length(), &bytesWritten, NULL)) {
-                  warn(ERR_WIN32_ERROR + GetLastError(), "cannot write to file \"%S\"", originFile.c_str());
+                  static int done = warn(ERR_WIN32_ERROR + GetLastError(), "cannot write to file \"%S\"", originFile.c_str());
                }
                CloseHandle(hFile);
             }
          }
+         result = wsdup(fileName.c_str());
       }
 
-      // make sure the config file exists
-      HANDLE hFile = CreateFileW(configPath, 0, FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
-      if (hFile == INVALID_HANDLE_VALUE) {
-         DWORD error = GetLastError();                               // ignore if open elsewhere
-         if (error != ERROR_FILE_EXISTS && error != ERROR_SHARING_VIOLATION) {
-            warn(ERR_WIN32_ERROR + error, "cannot create file \"%S\"", configPath);
+      // check "rsf-terminal-config.ini" for existence
+      else if (IsFileW(fileName.c_str(), MODE_SYSTEM)) {
+         result = wsdup(fileName.c_str());
+      }
+
+      else {
+         // rename an existing legacy config file
+         wstring legacyName = wstring(dataPath).append(L"\\terminal-config.ini");
+         if (IsFileW(legacyName.c_str(), MODE_SYSTEM)) {          // check legacy file for existence and rename it
+            if (MoveFileExW(legacyName.c_str(), fileName.c_str(), MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH|MOVEFILE_FAIL_IF_NOT_TRACKABLE)) {
+               info("renamed \"terminal-config.ini\" to \"rsf-terminal-config.ini\"");
+               result = wsdup(fileName.c_str());
+            }
+            else {
+               static int done = warn(ERR_WIN32_ERROR + GetLastError(), "cannot rename \"%S\" to \"%S\"", legacyName.c_str(), fileName.c_str());
+               result = wsdup(legacyName.c_str());                // keep using the old "terminal-config.ini"
+            }
+         }
+
+         // create "rsf-terminal-config.ini"
+         else {
+            HANDLE hFile = CreateFileW(fileName.c_str(), 0, FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+            if (hFile == INVALID_HANDLE_VALUE) {
+               if (GetLastError() != ERROR_SHARING_VIOLATION) {   // ignore if open elsewhere
+                  static int done = warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", fileName.c_str());
+               }
+            }
+            else {
+               CloseHandle(hFile);
+            }
+            result = wsdup(fileName.c_str());
          }
       }
-      else {
-         CloseHandle(hFile);
-      }
-   }
 
+      if (!configPath) configPath = result;
+      else             free(result);                              // another thread may have been faster
+   }
    return configPath;
    #pragma EXPANDER_EXPORT
 }

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -9,12 +9,14 @@
 
 
 /**
- * Return the full name of the global framework configuration file. The global configuration is used by all installed terminals
- * of the current user. The file is located in the common MetaTrader data folder and is named "global-config.ini". If the file
- * does not exist an attempt is made to create it.
+ * Return the full name of the user's global framework configuration file. This configuration file is used by all terminals
+ * installed by the user.
  *
- * @return char* - file name or NULL in case of errors,
- *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\Common\global-config.ini"
+ * The file is named "rsf-user-config.ini" and is located in the terminal's common data folder. If the file does not exist
+ * an attempt is made to
+ *
+ * @return char* - file name or a NULL pointer in case of errors,
+ *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\Common\rsf-user-config.ini"
  */
 const char* WINAPI GetGlobalConfigPathA() {
    static char* configPath;
@@ -23,7 +25,7 @@ const char* WINAPI GetGlobalConfigPathA() {
       const char* commonDataPath = GetTerminalCommonDataPathA();
       if (!commonDataPath) return NULL;
 
-      string filename = string(commonDataPath).append("\\global-config.ini");
+      string filename = string(commonDataPath).append("\\rsf-user-config.ini");
       char* tmp = sdup(filename.c_str());
       if (!configPath) configPath = tmp;
       else             free(tmp);                  // another thread may have been faster

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -9,16 +9,16 @@
 
 
 /**
- * Return the full name of the user's global framework configuration file. This configuration file is used by all terminals
- * installed by the user.
+ * Return the full name of the framework's user configuration file. This configuration file is used by all terminals installed
+ * by the user.
  *
  * The file is named "rsf-user-config.ini" and is located in the terminal's common data folder. If the file does not exist
- * an attempt is made to
+ * an attempt is made to create it.
  *
  * @return char* - file name or a NULL pointer in case of errors,
  *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\Common\rsf-user-config.ini"
  */
-const char* WINAPI GetGlobalConfigPathA() {
+const char* WINAPI GetUserConfigPathA() {
    static char* configPath;
 
    if (!configPath) {
@@ -110,16 +110,16 @@ const char* WINAPI GetTerminalConfigPathA() {
 
 
 /**
- * Whether a config key exists in the global configuration.
+ * Whether a config key exists in the user configuration.
  *
- * @param  char* section - case-insensitive config section name
- * @param  char* key     - case-insensitive config key
+ * @param  char* section - case insensitive config section name
+ * @param  char* key     - case insensitive config key
  *
  * @return BOOL
  */
-BOOL WINAPI IsGlobalConfigKeyA(const char* section, const char* key) {
-   const char* globalConfig = GetGlobalConfigPathA();
-   return globalConfig && IsIniKeyA(globalConfig, section, key);
+BOOL WINAPI IsUserConfigKeyA(const char* section, const char* key) {
+   const char* userConfig = GetUserConfigPathA();
+   return userConfig && IsIniKeyA(userConfig, section, key);
    #pragma EXPANDER_EXPORT
 }
 
@@ -127,8 +127,8 @@ BOOL WINAPI IsGlobalConfigKeyA(const char* section, const char* key) {
 /**
  * Whether a config key exists in the terminal configuration.
  *
- * @param  char* section - case-insensitive config section name
- * @param  char* key     - case-insensitive config key
+ * @param  char* section - case insensitive config section name
+ * @param  char* key     - case insensitive config key
  *
  * @return BOOL
  */
@@ -143,8 +143,8 @@ BOOL WINAPI IsTerminalConfigKeyA(const char* section, const char* key) {
  * Whether a config key exists in the specified .ini file.
  *
  * @param  char* fileName - name of the .ini file
- * @param  char* section  - case-insensitive config section
- * @param  char* key      - case-insensitive config key
+ * @param  char* section  - case insensitive config section
+ * @param  char* key      - case insensitive config key
  *
  * @return BOOL
  */
@@ -170,7 +170,7 @@ BOOL WINAPI IsIniKeyA(const char* fileName, const char* section, const char* key
    }
    char* lKey = strToLower(strim(sdupa(key)));
 
-   // look for a case-insensitive match
+   // look for a case insensitive match
    BOOL result = FALSE;
    char* name = buffer;                                  // The buffer is filled with one or more trimmed and NUL terminated
    while (*name) {                                       // strings. The last string is followed by a second NUL character.
@@ -192,8 +192,8 @@ BOOL WINAPI IsIniKeyA(const char* fileName, const char* section, const char* key
  * returned if creation fails.
  *
  * @param  char* fileName - name of the .ini file
- * @param  char* section  - case-insensitive config section name
- * @param  char* key      - case-insensitive config key to delete
+ * @param  char* section  - case insensitive config section name
+ * @param  char* key      - case insensitive config key to delete
  *
  * @return BOOL - success status
  */
@@ -217,7 +217,7 @@ BOOL WINAPI DeleteIniKeyA(const char* fileName, const char* section, const char*
  * Whether a config section exists in the specified .ini file.
  *
  * @param  char* fileName - name of the .ini file
- * @param  char* section  - case-insensitive config section name
+ * @param  char* section  - case insensitive config section name
  *
  * @return BOOL
  */
@@ -241,7 +241,7 @@ BOOL WINAPI IsIniSectionA(const char* fileName, const char* section) {
    }
    char* lSection = strToLower(strim(sdupa(section)));
 
-   // look for a case-insensitive match
+   // look for a case insensitive match
    BOOL result = FALSE;
    char* name = buffer;                                  // The buffer is filled with one or more trimmed and NUL terminated
    while (*name) {                                       // strings. The last string is followed by a second NUL character.
@@ -263,7 +263,7 @@ BOOL WINAPI IsIniSectionA(const char* fileName, const char* section) {
  * is returned if creation fails.
  *
  * @param  char* fileName - name of the .ini file
- * @param  char* section  - case-insensitive config section name
+ * @param  char* section  - case insensitive config section name
  *
  * @return BOOL - success status
  */
@@ -286,7 +286,7 @@ BOOL WINAPI DeleteIniSectionA(const char* fileName, const char* section) {
  * If the file does not exist an attempt is made to create it. No error is returned if file creation fails.
  *
  * @param  char* fileName - name of the .ini file
- * @param  char* section  - case-insensitive config section name
+ * @param  char* section  - case insensitive config section name
  *
  * @return BOOL - success status
  */
@@ -312,7 +312,7 @@ BOOL WINAPI EmptyIniSectionA(const char* fileName, const char* section) {
  * Alias of GetPrivateProfileString(). Required for MQL4.0 which doesn't support function overloading (multiple signatures).
  *
  * @param  _In_  char* fileName   - initialization file name
- * @param  _In_  char* section    - case-insensitive section name
+ * @param  _In_  char* section    - case insensitive section name
  * @param  _Out_ char* buffer     - Pointer to a buffer that receives the found keys. The buffer is filled with one or more
  *                                  NUL terminated strings. The last string is followed by a second NUL character.
  * @param  _In_  uint  bufferSize - size of the buffer in bytes (note: MQL4.0 has no unsigned integer type)
@@ -361,8 +361,8 @@ uint WINAPI GetIniSectionsA(const char* fileName, char* buffer, uint bufferSize)
  * Return a config value from an .ini file as a string. Enclosing white space and trailing comments are removed.
  *
  * @param  char* fileName                - name of the .ini file
- * @param  char* section                 - case-insensitive config section name
- * @param  char* key                     - case-insensitive config key
+ * @param  char* section                 - case insensitive config section name
+ * @param  char* key                     - case insensitive config key
  * @param  char* defaultValue [optional] - value to return if the specified key does not exist (default: empty string)
  *
  * @return char* - Config value or the default value if the config value does not exist (enclosing white space and inline
@@ -386,8 +386,8 @@ char* WINAPI GetIniStringA(const char* fileName, const char* section, const char
  * Return a config value from an .ini file as a raw string, including config line comments.
  *
  * @param  char* fileName                - name of the .ini file
- * @param  char* section                 - case-insensitive config section name
- * @param  char* key                     - case-insensitive config key
+ * @param  char* section                 - case insensitive config section name
+ * @param  char* key                     - case insensitive config key
  * @param  char* defaultValue [optional] - value to return if the specified key does not exist (default: empty string)
  *
  * @return char* - Config value or the default value if the config value does not exist (enclosing white space is removed).
@@ -418,10 +418,9 @@ char* WINAPI GetIniStringRawA(const char* fileName, const char* section, const c
 
 
 /**
- * Return a terminal config value as a boolean. Queries the global and the terminal configuration with the terminal configu-
- * ration superseeding the global one. Boolean values can be expressed by "0" or "1", "On" or "Off", "Yes" or "No" and "true" or
- * "false" (case insensitive). An empty value of an existing key is considered FALSE and a numeric value is considered TRUE if
- * its nominal value is non-zero. Trailing configuration comments are ignored.
+ * Return a config value as a boolean. Boolean values can be expressed by "0" or "1", "On" or "Off", "Yes" or "No" and "true"
+ * or "false" (case insensitive). An empty value of an existing key is considered FALSE and a numeric value is considered TRUE
+ * if its nominal value is non-zero. Trailing configuration comments are ignored.
  *
  * @param  char* section      - configuration section name
  * @param  char* key          - configuration key
@@ -430,8 +429,7 @@ char* WINAPI GetIniStringRawA(const char* fileName, const char* section, const c
  * @return BOOL - configuration value
  */
 //BOOL WINAPI GetConfigBool(const char* section, const char* key, BOOL defaultValue/*=FALSE*/) {
-//   // It's faster to always evaluate global and local configuration: internally only one call of GetPrivateProfileString().    // TODO: true?
-//   //BOOL result = GetGlobalConfigBool(section, key, defaultValue);
+//   //BOOL result = GetUserConfigBool(section, key, defaultValue);
 //   //return GetTerminalConfigBool(section, key, result);
 //   return FALSE;
 //}

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -49,12 +49,15 @@ const char* WINAPI GetGlobalConfigPathA() {
 
 
 /**
- * Return the full name of the terminal-specific framework configuration file. This configuration file is used by the currently
- * active terminal only. The file is located in the terminal-specific data folder and is named "terminal-config.ini". If the
- * file does not exist an attempt is made to create it.
+ * Returns the full name of the terminal-specific configuration file. This configuration file is used by the currently active
+ * terminal only.
  *
- * @return char* - filename or NULL in case of errors,
- *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\{installation-id}\terminal-config.ini"
+ * The file is named "rsf-terminal-config.ini" and is located in the terminal-specific data folder. If the terminal runs in
+ * "portable mode", the data folder is the terminal's installation folder. If the file does not exist an attempt is made to
+ * create it.
+ *
+ * @return char* - file name or a NULL pointer in case of errors,
+ *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\{installation-id}\rsf-terminal-config.ini"
  */
 const char* WINAPI GetTerminalConfigPathA() {
    static char* configPath;
@@ -63,12 +66,12 @@ const char* WINAPI GetTerminalConfigPathA() {
       const char* dataPath = GetTerminalDataPathA();
       if (!dataPath) return NULL;
 
-      string iniFile = string(dataPath).append("\\terminal-config.ini");
+      string iniFile = string(dataPath).append("\\rsf-terminal-config.ini");
       char* tmp = sdup(iniFile.c_str());
       if (!configPath) configPath = tmp;
       else             free(tmp);                                          // another thread may have been faster
 
-      // make sure the config directory exists (e.g. if in non-portable mode)
+      // make sure the config directory exists (applies to non-portable mode only)
       if (!IsDirectoryA(dataPath, MODE_SYSTEM)) {
          int error = CreateDirectoryA(dataPath, MODE_SYSTEM|MODE_MKPARENT);
          if (error) {

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -66,12 +66,13 @@ const wchar* WINAPI GetUserConfigPathW() {
       else {                                                      // check "global-config.ini" for existence
          wstring legacyName = wstring(commonDataPath).append(L"\\global-config.ini");
          if (IsFileW(legacyName.c_str(), MODE_SYSTEM)) {          // rename "global-config.ini" to "rsf-user-config.ini"
-            if (!MoveFileExW(legacyName.c_str(), fileName.c_str(), MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH|MOVEFILE_FAIL_IF_NOT_TRACKABLE)) {
-               static int done = warn(ERR_WIN32_ERROR + GetLastError(), "cannot rename \"%S\" to \"%S\"", legacyName.c_str(), fileName.c_str());
-               result = wsdup(legacyName.c_str());                // keep using old "global-config.ini"
+            if (MoveFileExW(legacyName.c_str(), fileName.c_str(), MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH|MOVEFILE_FAIL_IF_NOT_TRACKABLE)) {
+               info("renamed \"%S\" to \"%S\"", legacyName.c_str(), fileName.c_str());
+               result = wsdup(fileName.c_str());
             }
             else {
-               result = wsdup(fileName.c_str());
+               static int done = warn(ERR_WIN32_ERROR + GetLastError(), "cannot rename \"%S\" to \"%S\"", legacyName.c_str(), fileName.c_str());
+               result = wsdup(legacyName.c_str());                // keep using the old "global-config.ini"
             }
          }
          else {                                                   // create "rsf-user-config.ini"

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -63,7 +63,7 @@ const wchar* WINAPI GetUserConfigPathW() {
             warn(error, "cannot create directory \"%S\"", commonDataPath);
          }
          else {
-            // make sure the file exists (OPEN_ALWAYS: create if missing)
+            // make sure the config file exists
             HANDLE hFile = CreateFileW(configPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
             if (hFile == INVALID_HANDLE_VALUE) {
                warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", configPath);
@@ -162,7 +162,7 @@ const wchar* WINAPI GetTerminalConfigPathW() {
       }
 
       // make sure the config file exists
-      if (!IsFileW(configPath, MODE_SYSTEM)) {                       // create if missing
+      if (!IsFileW(configPath, MODE_SYSTEM)) {
          HANDLE hFile = CreateFileW(configPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
          if (hFile == INVALID_HANDLE_VALUE) {
             if (GetLastError() != ERROR_SHARING_VIOLATION) {         // ignore if open elsewhere

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -5,8 +5,6 @@
 #include "lib/string.h"
 #include "lib/terminal.h"
 
-#include <fstream>
-
 
 /**
  * Return the full name of the framework's user configuration file.
@@ -54,7 +52,7 @@ const wchar* WINAPI GetUserConfigPathW() {
       wstring filename = wstring(commonDataPath).append(L"\\rsf-user-config.ini");
       wchar* tmp = wsdup(filename.c_str());
       if (!configPath) configPath = tmp;
-      else             free(tmp);                  // another thread may have been faster
+      else             free(tmp);                                 // another thread may have been faster
 
       if (!IsFileW(configPath, MODE_SYSTEM)) {
          // make sure the config directory exists
@@ -64,9 +62,11 @@ const wchar* WINAPI GetUserConfigPathW() {
          }
          else {
             // make sure the config file exists
-            HANDLE hFile = CreateFileW(configPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+            HANDLE hFile = CreateFileW(configPath, 0, FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
             if (hFile == INVALID_HANDLE_VALUE) {
-               warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", configPath);
+               if (GetLastError() != ERROR_SHARING_VIOLATION) {   // ignore if open elsewhere
+                  warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", configPath);
+               }
             }
             else {
                CloseHandle(hFile);
@@ -142,36 +142,34 @@ const wchar* WINAPI GetTerminalConfigPathW() {
          if (!StrCompare(terminalPath, dataPath)) {
             wstring originFile = wstring(dataPath).append(L"\\origin.txt");
 
-            if (!IsFileW(originFile.c_str(), MODE_SYSTEM)) {
-               HANDLE hFile = CreateFileW(originFile.c_str(), GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-               if (hFile == INVALID_HANDLE_VALUE) {
-                  if (GetLastError() != ERROR_SHARING_VIOLATION) {   // ignore if open elsewhere
-                     warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", originFile.c_str());
-                  }
+            HANDLE hFile = CreateFileW(originFile.c_str(), GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_DELETE, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
+            if (hFile == INVALID_HANDLE_VALUE) {
+               DWORD error = GetLastError();                         // ignore if open elsewhere
+               if (error != ERROR_FILE_EXISTS && error != ERROR_SHARING_VIOLATION) {
+                  warn(ERR_WIN32_ERROR + error, "cannot create file \"%S\"", originFile.c_str());
                }
-               else {
-                  string content = utf16ToAnsi(wstring(terminalPath)).append(CRLF);
-                  DWORD bytesWritten;
-                  if (!WriteFile(hFile, content.c_str(), (DWORD)content.length(), &bytesWritten, NULL)) {
-                     warn(ERR_WIN32_ERROR + GetLastError(), "cannot write to file \"%S\"", originFile.c_str());
-                  }
-                  CloseHandle(hFile);
+            }
+            else {
+               string content = utf16ToAnsi(wstring(terminalPath)).append(CRLF);
+               DWORD bytesWritten;
+               if (!WriteFile(hFile, content.c_str(), (DWORD)content.length(), &bytesWritten, NULL)) {
+                  warn(ERR_WIN32_ERROR + GetLastError(), "cannot write to file \"%S\"", originFile.c_str());
                }
+               CloseHandle(hFile);
             }
          }
       }
 
       // make sure the config file exists
-      if (!IsFileW(configPath, MODE_SYSTEM)) {
-         HANDLE hFile = CreateFileW(configPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-         if (hFile == INVALID_HANDLE_VALUE) {
-            if (GetLastError() != ERROR_SHARING_VIOLATION) {         // ignore if open elsewhere
-               warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", configPath);
-            }
+      HANDLE hFile = CreateFileW(configPath, 0, FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
+      if (hFile == INVALID_HANDLE_VALUE) {
+         DWORD error = GetLastError();                               // ignore if open elsewhere
+         if (error != ERROR_FILE_EXISTS && error != ERROR_SHARING_VIOLATION) {
+            warn(ERR_WIN32_ERROR + error, "cannot create file \"%S\"", configPath);
          }
-         else {
-            CloseHandle(hFile);
-         }
+      }
+      else {
+         CloseHandle(hFile);
       }
    }
 

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -174,7 +174,10 @@ const wchar* WINAPI GetTerminalConfigPathW() {
                CloseHandle(hFile);
             }
          }
-         result = wsdup(fileName.c_str());
+      }
+
+      if (!IsDirectoryW(dataPath, MODE_SYSTEM)) {
+         result = wsdup(fileName.c_str());                        // directory creation attempt failed
       }
 
       // check "rsf-terminal-config.ini" for existence

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -9,11 +9,11 @@
 
 
 /**
- * Return the full name of the framework's user configuration file. This configuration file is used by all terminals installed
- * by the user.
+ * Return the full name of the framework's user configuration file.
  *
- * The file is named "rsf-user-config.ini" and is located in the terminal's common data folder. If the file does not exist
- * an attempt is made to create it.
+ * - This configuration file is used by all terminals installed by the user.
+ * - The file is named "rsf-user-config.ini" and is located in the terminal's common data folder.
+ * - If the file does not exist an attempt is made to create it.
  *
  * @return char* - file name or a NULL pointer in case of errors,
  *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\Common\rsf-user-config.ini"
@@ -31,13 +31,13 @@ const char* WINAPI GetUserConfigPathA() {
       else             free(tmp);                  // another thread may have been faster
 
       if (!IsFileA(configPath, MODE_SYSTEM)) {
-         // make sure the config directory exists
+         // make sure the directory exists
          int error = CreateDirectoryA(commonDataPath, MODE_SYSTEM|MODE_MKPARENT);
          if (error) {
             warn(error, "cannot create directory \"%s\" (%s)", commonDataPath, strerror(errno));
          }
          else {
-            // make sure the config file exists
+            // make sure the file exists
             std::ofstream file(configPath);
             if (file.is_open()) file.close();
             else                warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%s\" (%s)", configPath, strerror(errno));
@@ -51,12 +51,57 @@ const char* WINAPI GetUserConfigPathA() {
 
 
 /**
- * Returns the full name of the terminal-specific configuration file. This configuration file is used by the currently active
- * terminal only.
+ * Return the full name of the framework's user configuration file.
  *
- * The file is named "rsf-terminal-config.ini" and is located in the terminal-specific data folder. If the terminal runs in
- * "portable mode", the data folder is the terminal's installation folder. If the file does not exist an attempt is made to
- * create it.
+ * - This configuration file is used by all terminals installed by the user.
+ * - The file is named "rsf-user-config.ini" and is located in the terminal's common data folder.
+ * - If the file does not exist an attempt is made to create it.
+ *
+ * @return char* - file name or a NULL pointer in case of errors,
+ *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\Common\rsf-user-config.ini"
+ */
+const wchar* WINAPI GetUserConfigPathW() {
+   static wchar* configPath;
+
+   if (!configPath) {
+      const wchar* commonDataPath = GetTerminalCommonDataPathW();
+      if (!commonDataPath) return NULL;
+
+      wstring filename = wstring(commonDataPath).append(L"\\rsf-user-config.ini");
+      wchar* tmp = wsdup(filename.c_str());
+      if (!configPath) configPath = tmp;
+      else             free(tmp);                  // another thread may have been faster
+
+      if (!IsFileW(configPath, MODE_SYSTEM)) {
+         // make sure the directory exists
+         int error = CreateDirectoryW(commonDataPath, MODE_SYSTEM|MODE_MKPARENT);
+         if (error) {
+            warn(error, "cannot create directory \"%S\"", commonDataPath);
+         }
+         else {
+            // make sure the file exists (OPEN_ALWAYS: create if missing)
+            HANDLE hFile = CreateFileW(configPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+            if (hFile == INVALID_HANDLE_VALUE) {
+               warn(ERR_WIN32_ERROR + GetLastError(), "cannot create file \"%S\"", configPath);
+            }
+            else {
+               CloseHandle(hFile);
+            }
+         }
+      }
+   }
+   return configPath;
+   #pragma EXPANDER_EXPORT
+}
+
+
+/**
+ * Returns the full name of the terminal-specific configuration file.
+ *
+ * - This configuration file is used by the currently active terminal only.
+ * - The file is named "rsf-terminal-config.ini" and is located in the terminal-specific data folder. If the terminal runs in
+ *   "portable mode", the data folder is the terminal's installation folder.
+ * - If the file does not exist an attempt is made to create it.
  *
  * @return char* - file name or a NULL pointer in case of errors,
  *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\{installation-id}\rsf-terminal-config.ini"

--- a/src/lib/datetime.cpp
+++ b/src/lib/datetime.cpp
@@ -1006,7 +1006,7 @@ const TimezoneMapping* WINAPI GetTimeZoneMappings() {
 /**
  * Get a timezone id for an IANA timezone name.
  *
- * @param  char* name - case-insensitive IANA timezone name
+ * @param  char* name - case insensitive IANA timezone name
  *
  * @return int - timezone id or NULL if no timezone with that name was found
  */
@@ -1026,7 +1026,7 @@ int WINAPI GetTimeZoneIdByIanaNameA(const char* name) {
 /**
  * Get a timezone id for an IANA timezone name.
  *
- * @param  wchar* name - case-insensitive IANA timezone name
+ * @param  wchar* name - case insensitive IANA timezone name
  *
  * @return int - timezone id or NULL if no timezone with that name was found
  */

--- a/src/lib/file.cpp
+++ b/src/lib/file.cpp
@@ -29,8 +29,8 @@
 int WINAPI CreateDirectoryA(const char* path, DWORD flags) {
    if ((uint)path < MIN_VALID_POINTER)     return error(ERR_INVALID_PARAMETER, "invalid parameter path: 0x%p (not a valid pointer)", path);
    if (!*path)                             return error(ERR_INVALID_PARAMETER, "invalid parameter path: \"\" (empty)");
-   if (!(~flags & (MODE_MQL|MODE_SYSTEM))) return error(ERR_INVALID_PARAMETER, "invalid parameter flag: only one of MODE_MQL or MODE_SYSTEM can be specified");
-   if (!( flags & (MODE_MQL|MODE_SYSTEM))) return error(ERR_INVALID_PARAMETER, "invalid parameter flag: one of MODE_MQL or MODE_SYSTEM must be specified");
+   if (!(~flags & (MODE_MQL|MODE_SYSTEM))) return error(ERR_INVALID_PARAMETER, "invalid parameter flags: only one of MODE_MQL or MODE_SYSTEM can be specified");
+   if (!( flags & (MODE_MQL|MODE_SYSTEM))) return error(ERR_INVALID_PARAMETER, "invalid parameter flags: one of MODE_MQL or MODE_SYSTEM must be specified");
 
    if (flags & MODE_MQL) {
       return error(ERR_NOT_IMPLEMENTED, "support for flag MODE_MQL not yet implemented");
@@ -55,7 +55,7 @@ int WINAPI CreateDirectoryA(const char* path, DWORD flags) {
       }
 
       // create the final directory
-      if (CreateDirectory(path, (LPSECURITY_ATTRIBUTES)NULL)) {
+      if (CreateDirectoryA(path, (LPSECURITY_ATTRIBUTES)NULL)) {
          return NO_ERROR;
       }
 
@@ -64,6 +64,59 @@ int WINAPI CreateDirectoryA(const char* path, DWORD flags) {
          return NO_ERROR;
       }
       return error(ERR_WIN32_ERROR + GetLastError(), "creation of \"%s\" failed", path);
+   }
+   #pragma EXPANDER_EXPORT
+}
+
+
+/**
+ * Create a directory.
+ *
+ * @param  wchar* path  - directory path
+ * @param  DWORD  flags - MODE_MQL:      restrict the function's operation to the MQL sandbox
+ *                        MODE_SYSTEM:   allow the function to operate outside of the MQL sandbox
+ *                        MODE_MKPARENT: create parent directories as needed and report no error on an existing directory;
+ *                                       otherwise create only the final directory and report an error if it exists
+ * @return int - error status
+ */
+int WINAPI CreateDirectoryW(const wchar* path, DWORD flags) {
+   if ((uint)path < MIN_VALID_POINTER)     return error(ERR_INVALID_PARAMETER, "invalid parameter path: 0x%p (not a valid pointer)", path);
+   if (!*path)                             return error(ERR_INVALID_PARAMETER, "invalid parameter path: \"\" (empty)");
+   if (!(~flags & (MODE_MQL|MODE_SYSTEM))) return error(ERR_INVALID_PARAMETER, "invalid parameter flags: only one of MODE_MQL or MODE_SYSTEM can be specified");
+   if (!( flags & (MODE_MQL|MODE_SYSTEM))) return error(ERR_INVALID_PARAMETER, "invalid parameter flags: one of MODE_MQL or MODE_SYSTEM must be specified");
+
+   if (flags & MODE_MQL) {
+      return error(ERR_NOT_IMPLEMENTED, "support for flag MODE_MQL not yet implemented");
+   }
+   else /*flags & MODE_SYSTEM*/ {
+      // check whether such a file or directory already exists
+      if (IsFileOrDirectoryW(path)) {
+         if (!IsDirectoryW(path, MODE_SYSTEM))  return error(ERR_WIN32_ERROR + ERROR_FILE_EXISTS, "cannot create directory \"%S\" (a file of the same name already exists)", path);
+         if (!(flags & MODE_MKPARENT))          return error(ERR_WIN32_ERROR + ERROR_ALREADY_EXISTS, "directory \"%S\" already exists", path);
+         return NO_ERROR;
+      }
+
+      // make sure a parent directory exists
+      if (flags & MODE_MKPARENT) {
+         wstring sPath = wstring(path);
+         size_t pos = sPath.find_last_of(L"\\/");
+         if (pos != wstring::npos) {
+            if (pos == 0) return error(ERR_INVALID_PARAMETER, "invalid parameter path: \"%S\"", path);
+            int error = CreateDirectoryW(sPath.substr(0, pos).c_str(), flags);
+            if (error) return error;
+         }
+      }
+
+      // create the final directory
+      if (CreateDirectoryW(path, (LPSECURITY_ATTRIBUTES)NULL)) {
+         return NO_ERROR;
+      }
+
+      // with multiple path separators the directory may already exist
+      if (GetLastError() == ERROR_ALREADY_EXISTS && (flags & MODE_MKPARENT)) {
+         return NO_ERROR;
+      }
+      return error(ERR_WIN32_ERROR + GetLastError(), "creation of \"%S\" failed", path);
    }
    #pragma EXPANDER_EXPORT
 }
@@ -88,6 +141,33 @@ BOOL WINAPI IsDirectoryA(const char* path, DWORD mode) {
       }
       else /*mode & MODE_SYSTEM*/ {
          DWORD attributes = GetFileAttributesA(path);
+         return (attributes != INVALID_FILE_ATTRIBUTES) && (attributes & FILE_ATTRIBUTE_DIRECTORY);
+      }
+   }
+   return FALSE;
+   #pragma EXPANDER_EXPORT
+}
+
+
+/**
+ * Whether the specified directory exists and is not a regular file. Symbolic links and junctions are supported.
+ *
+ * @param  wchar* path - directory path with support for forward, backward and trailing slashes
+ * @param  DWORD  mode - MODE_MQL:    restrict the function's operation to the MQL sandbox
+ *                       MODE_SYSTEM: allow the function to operate outside of the MQL sandbox
+ * @return BOOL
+ */
+BOOL WINAPI IsDirectoryW(const wchar* path, DWORD mode) {
+   if (path) {
+      if ((uint)path < MIN_VALID_POINTER)    return !error(ERR_INVALID_PARAMETER, "invalid parameter path: 0x%p (not a valid pointer)", path);
+      if (!(~mode & (MODE_MQL|MODE_SYSTEM))) return !error(ERR_INVALID_PARAMETER, "invalid parameter mode: only one of MODE_MQL or MODE_SYSTEM can be specified");
+      if (!( mode & (MODE_MQL|MODE_SYSTEM))) return !error(ERR_INVALID_PARAMETER, "invalid parameter mode: one of MODE_MQL or MODE_SYSTEM must be specified");
+
+      if (mode & MODE_MQL) {
+         return !error(ERR_NOT_IMPLEMENTED, "support for MODE_MQL not yet implemented");
+      }
+      else /*mode & MODE_SYSTEM*/ {
+         DWORD attributes = GetFileAttributesW(path);
          return (attributes != INVALID_FILE_ATTRIBUTES) && (attributes & FILE_ATTRIBUTE_DIRECTORY);
       }
    }
@@ -159,12 +239,31 @@ BOOL WINAPI IsFileW(const wchar* path, DWORD mode) {
  */
 BOOL WINAPI IsFileOrDirectoryA(const char* name) {
    if (name) {
-      if ((uint)name < MIN_VALID_POINTER) return(!error(ERR_INVALID_PARAMETER, "invalid parameter name: 0x%p (not a valid pointer)", name));
+      if ((uint)name < MIN_VALID_POINTER) return !error(ERR_INVALID_PARAMETER, "invalid parameter name: 0x%p (not a valid pointer)", name);
 
-      DWORD attributes = GetFileAttributes(name);
-      return(attributes != INVALID_FILE_ATTRIBUTES);
+      DWORD attributes = GetFileAttributesA(name);
+      return (attributes != INVALID_FILE_ATTRIBUTES);
    }
-   return(FALSE);
+   return FALSE;
+   #pragma EXPANDER_EXPORT
+}
+
+
+/**
+ * Whether the specified file or directory exists. Symbolic links and junctions are supported.
+ *
+ * @param  wchar* name - full name with support for forward, backward and trailing slashes
+ *
+ * @return BOOL
+ */
+BOOL WINAPI IsFileOrDirectoryW(const wchar* name) {
+   if (name) {
+      if ((uint)name < MIN_VALID_POINTER) return !error(ERR_INVALID_PARAMETER, "invalid parameter name: 0x%p (not a valid pointer)", name);
+
+      DWORD attributes = GetFileAttributesW(name);
+      return (attributes != INVALID_FILE_ATTRIBUTES);
+   }
+   return FALSE;
    #pragma EXPANDER_EXPORT
 }
 

--- a/src/lib/file.cpp
+++ b/src/lib/file.cpp
@@ -32,39 +32,8 @@ int WINAPI CreateDirectoryA(const char* path, DWORD flags) {
    if (!(~flags & (MODE_MQL|MODE_SYSTEM))) return error(ERR_INVALID_PARAMETER, "invalid parameter flags: only one of MODE_MQL or MODE_SYSTEM can be specified");
    if (!( flags & (MODE_MQL|MODE_SYSTEM))) return error(ERR_INVALID_PARAMETER, "invalid parameter flags: one of MODE_MQL or MODE_SYSTEM must be specified");
 
-   if (flags & MODE_MQL) {
-      return error(ERR_NOT_IMPLEMENTED, "support for flag MODE_MQL not yet implemented");
-   }
-   else /*flags & MODE_SYSTEM*/ {
-      // check whether such a file or directory already exists
-      if (IsFileOrDirectoryA(path)) {
-         if (!IsDirectoryA(path, MODE_SYSTEM)) return error(ERR_WIN32_ERROR + ERROR_FILE_EXISTS, "cannot create directory \"%s\" (a file of the same name already exists)", path);
-         if (!(flags & MODE_MKPARENT))         return error(ERR_WIN32_ERROR + ERROR_ALREADY_EXISTS, "directory \"%s\" already exists", path);
-         return NO_ERROR;
-      }
-
-      // make sure a parent directory exists
-      if (flags & MODE_MKPARENT) {
-         string sPath = string(path);
-         size_t pos = sPath.find_last_of("\\/");
-         if (pos != string::npos) {
-            if (pos == 0) return error(ERR_INVALID_PARAMETER, "invalid parameter path: \"%s\"", path);
-            int error = CreateDirectoryA(sPath.substr(0, pos).c_str(), flags);
-            if (error) return error;
-         }
-      }
-
-      // create the final directory
-      if (CreateDirectoryA(path, (LPSECURITY_ATTRIBUTES)NULL)) {
-         return NO_ERROR;
-      }
-
-      // with multiple path separators the directory may already exist
-      if (GetLastError() == ERROR_ALREADY_EXISTS && (flags & MODE_MKPARENT)) {
-         return NO_ERROR;
-      }
-      return error(ERR_WIN32_ERROR + GetLastError(), "creation of \"%s\" failed", path);
-   }
+   wstring wpath = ansiToUtf16(string(path));
+   return CreateDirectoryW(wpath.c_str(), flags);
    #pragma EXPANDER_EXPORT
 }
 
@@ -136,13 +105,8 @@ BOOL WINAPI IsDirectoryA(const char* path, DWORD mode) {
       if (!(~mode & (MODE_MQL|MODE_SYSTEM))) return !error(ERR_INVALID_PARAMETER, "invalid parameter mode: only one of MODE_MQL or MODE_SYSTEM can be specified");
       if (!( mode & (MODE_MQL|MODE_SYSTEM))) return !error(ERR_INVALID_PARAMETER, "invalid parameter mode: one of MODE_MQL or MODE_SYSTEM must be specified");
 
-      if (mode & MODE_MQL) {
-         return !error(ERR_NOT_IMPLEMENTED, "support for MODE_MQL not yet implemented");
-      }
-      else /*mode & MODE_SYSTEM*/ {
-         DWORD attributes = GetFileAttributesA(path);
-         return (attributes != INVALID_FILE_ATTRIBUTES) && (attributes & FILE_ATTRIBUTE_DIRECTORY);
-      }
+      wstring wpath = ansiToUtf16(string(path));
+      return IsDirectoryW(wpath.c_str(), mode);
    }
    return FALSE;
    #pragma EXPANDER_EXPORT
@@ -190,13 +154,8 @@ BOOL WINAPI IsFileA(const char* path, DWORD mode) {
       if (!(~mode & (MODE_MQL|MODE_SYSTEM))) return !error(ERR_INVALID_PARAMETER, "invalid parameter mode: only one of MODE_MQL or MODE_SYSTEM can be specified");
       if (!( mode & (MODE_MQL|MODE_SYSTEM))) return !error(ERR_INVALID_PARAMETER, "invalid parameter mode: one of MODE_MQL or MODE_SYSTEM must be specified");
 
-      if (mode & MODE_MQL) {
-         return !error(ERR_NOT_IMPLEMENTED, "support for MODE_MQL not yet implemented");
-      }
-      else /*MODE_SYSTEM*/ {
-         DWORD attributes = GetFileAttributesA(path);
-         return (attributes != INVALID_FILE_ATTRIBUTES) && !(attributes & FILE_ATTRIBUTE_DIRECTORY);
-      }
+      wstring wpath = ansiToUtf16(string(path));
+      return IsFileW(wpath.c_str(), mode);
    }
    return FALSE;
    #pragma EXPANDER_EXPORT
@@ -241,8 +200,8 @@ BOOL WINAPI IsFileOrDirectoryA(const char* name) {
    if (name) {
       if ((uint)name < MIN_VALID_POINTER) return !error(ERR_INVALID_PARAMETER, "invalid parameter name: 0x%p (not a valid pointer)", name);
 
-      DWORD attributes = GetFileAttributesA(name);
-      return (attributes != INVALID_FILE_ATTRIBUTES);
+      wstring wname = ansiToUtf16(string(name));
+      return IsFileOrDirectoryW(wname.c_str());
    }
    return FALSE;
    #pragma EXPANDER_EXPORT

--- a/src/lib/file.cpp
+++ b/src/lib/file.cpp
@@ -60,8 +60,8 @@ int WINAPI CreateDirectoryW(const wchar* path, DWORD flags) {
    else /*flags & MODE_SYSTEM*/ {
       // check whether such a file or directory already exists
       if (IsFileOrDirectoryW(path)) {
-         if (!IsDirectoryW(path, MODE_SYSTEM))  return error(ERR_WIN32_ERROR + ERROR_FILE_EXISTS, "cannot create directory \"%S\" (a file of the same name already exists)", path);
-         if (!(flags & MODE_MKPARENT))          return error(ERR_WIN32_ERROR + ERROR_ALREADY_EXISTS, "directory \"%S\" already exists", path);
+         if (!IsDirectoryW(path, MODE_SYSTEM)) return error(ERR_WIN32_ERROR + ERROR_FILE_EXISTS, "cannot create directory \"%S\" (a file of the same name already exists)", path);
+         if (!(flags & MODE_MKPARENT))         return error(ERR_WIN32_ERROR + ERROR_ALREADY_EXISTS, "directory \"%S\" already exists", path);
          return NO_ERROR;
       }
 

--- a/src/lib/string.cpp
+++ b/src/lib/string.cpp
@@ -302,7 +302,7 @@ BOOL WINAPI StrStartsWith(const wchar* str, const wchar* prefix) {
 
 
 /**
- * Whether a C string ends with the specified substring (case-sensitive).
+ * Whether a C string ends with the specified substring (case sensitive).
  *
  * @param  char* str
  * @param  char* suffix
@@ -327,7 +327,7 @@ BOOL WINAPI StrEndsWith(const char* str, const char* suffix) {
 
 
 /**
- * Whether a C string ends with the specified substring (case-insensitive).
+ * Whether a C string ends with the specified substring (case insensitive).
  *
  * @param  char* str
  * @param  char* suffix
@@ -352,7 +352,7 @@ BOOL WINAPI StrEndsWithI(const char* str, const char* suffix) {
 
 
 /**
- * Whether a UTF-16 string ends with the specified substring (case-sensitive).
+ * Whether a UTF-16 string ends with the specified substring (case sensitive).
  *
  * @param  wchar* str
  * @param  wchar* suffix
@@ -377,7 +377,7 @@ BOOL WINAPI StrEndsWith(const wchar* str, const wchar* suffix) {
 
 
 /**
- * Whether a UTF-16 string ends with the specified substring (case-insensitive).
+ * Whether a UTF-16 string ends with the specified substring (case insensitive).
  *
  * @param  wchar* str
  * @param  wchar* suffix

--- a/src/lib/terminal.cpp
+++ b/src/lib/terminal.cpp
@@ -422,8 +422,8 @@ uint WINAPI GetTerminalBuild() {
  * introduced in MQL4.5). The common data directory is shared between all terminals installed by a user. The function does not
  * check whether the returned directory exists.
  *
- * @return char* - directory name without trailing path separator, e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\Common";
- *                 or a NULL pointer in case of errors
+ * @return char* - directory name without trailing path separator or a NULL pointer in case of errors,
+ *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\Common"
  */
 const char* WINAPI GetTerminalCommonDataPathA() {
    static char* path;

--- a/src/lib/terminal.cpp
+++ b/src/lib/terminal.cpp
@@ -944,7 +944,7 @@ BOOL WINAPI IsPortableMode() {
  *
  * @param  HWND        hChart      - handle of the chart to load the program on = value of MQL::WindowHandle()
  * @param  ProgramType programType - MQL program type: PT_INDICATOR | PT_EXPERT | PT_SCRIPT
- * @param  char*       programName - MQL program name (C string)
+ * @param  char*       programName - MQL program name
  *
  * @return BOOL - whether the load command was successfully queued; not whether the program was indeed launched
  */
@@ -962,7 +962,7 @@ BOOL WINAPI LoadMqlProgramA(HWND hChart, ProgramType programType, const char* pr
  *
  * @param  HWND        hChart      - handle of the chart to load the program on = value of MQL::WindowHandle()
  * @param  ProgramType programType - MQL program type: PT_INDICATOR | PT_EXPERT | PT_SCRIPT
- * @param  wchar*      programName - MQL program name (UTF-16)
+ * @param  wchar*      programName - MQL program name
  *
  * @return BOOL - whether the load command was successfully queued; not whether the program was indeed launched
  */

--- a/src/lib/terminal.cpp
+++ b/src/lib/terminal.cpp
@@ -418,9 +418,9 @@ uint WINAPI GetTerminalBuild() {
 
 
 /**
- * Return the full path of the terminal's common data directory (same value as returned by TerminalInfoString(TERMINAL_COMMONDATA_PATH)
- * introduced in MQL4.5). The common data directory is shared between all terminals installed by a user. The function does not
- * check whether the returned directory exists.
+ * Return the full path of the terminal's common data directory (same as returned by TerminalInfoString(TERMINAL_COMMONDATA_PATH)
+ * in MQL4.5). The common data directory is shared between all terminals installed by a user. The function does not check whether
+ * the returned directory exists.
  *
  * @return char* - directory name without trailing path separator or a NULL pointer in case of errors,
  *                 e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\Common"
@@ -442,12 +442,12 @@ const char* WINAPI GetTerminalCommonDataPathA() {
 
 
 /**
- * Return the full path of the terminal's common data directory (same value as returned by TerminalInfoString(TERMINAL_COMMONDATA_PATH)
- * introduced in MQL4.5). The common data directory is shared between all terminals installed by a user. The function does not
- * check whether the returned directory exists.
+ * Return the full path of the terminal's common data directory (same as returned by TerminalInfoString(TERMINAL_COMMONDATA_PATH)
+ * in MQL4.5). The common data directory is shared between all terminals installed by a user. The function does not check whether
+ * the returned directory exists.
  *
- * @return wchar* - directory name without trailing path separator, e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\Common";
- *                  or a NULL pointer in case of errors
+ * @return wchar* - directory name without trailing path separator or a NULL pointer in case of errors,
+ *                  e.g. "%UserProfile%\AppData\Roaming\MetaQuotes\Terminal\Common";
  */
 const wchar* WINAPI GetTerminalCommonDataPathW() {
    static wchar* path;


### PR DESCRIPTION
see #57 

- all config functions use the new names
- on first access an existing `global-config.ini` is renamed to `rsf-user-config.ini`
- on first access an existing `terminal-config.ini` is renamed to `rsf-terminal-config.ini`

@codex review